### PR TITLE
feat: infer uds-x configurations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: build-docker-image
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
@@ -49,6 +46,6 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# uds-compose-bridge
+# compose-bridge-uds
 
 A [Docker Compose Bridge](https://docs.docker.com/compose/bridge/) transformation that converts a Compose application into a deployable [UDS](https://uds.defenseunicorns.com/) package. It receives the fully-resolved Compose model as input and produces a Zarf package definition with Kubernetes manifests and a UDS Package CR, ready for `zarf package create` and deploy.
 
@@ -15,7 +15,7 @@ cd examples/full
 docker compose build
 
 # run the transformation
-docker compose bridge convert -t ghcr.io/defenseunicorns-dashdays/compose-bridge-uds:latest
+docker compose bridge convert -t ghcr.io/defenseunicorns-dashdays/compose-bridge-uds
 
 # build and deploy the package
 zarf package create out/
@@ -50,7 +50,7 @@ The bridge automatically generates a [UDS Package CR](https://docs.defenseunicor
 #### What is auto-generated
 
 - **Expose**: services with published `ports:` are exposed on the tenant gateway (`host` = service name, `gateway` = `tenant`, `selector`/`podLabels` = `app.kubernetes.io/name: <service>`)
-- **Network allow**: intra-namespace ingress/egress rules are always included; `depends_on:` relationships generate egress rules to the dependency's primary port
+- **Network allow**: intra-namespace ingress/egress rules are always included, allowing all services in the namespace to communicate
 - **SSO**: a Keycloak client is generated for the first exposed service (`clientId` = project name, `redirectUris` = `https://<host>.uds.dev/*`); omitted when no services are exposed
 
 #### Overriding defaults with `x-uds`

--- a/README.md
+++ b/README.md
@@ -43,36 +43,35 @@ The transformation maps the Compose model (as defined by the [Compose Specificat
 - **Bind mounts** — use Compose `configs:`, `secrets:`, or named `volumes:` instead
 - **External configs** — configs must define inline `content:`; referencing external files is not supported
 
-### UDS Package CR custom extensions
+### UDS Package CR inference and overrides
 
-Use [`x-uds`](https://docs.docker.com/reference/compose-file/extension/) at the top level of your `compose.yaml` to express UDS-specific configuration that cannot be inferred from the Compose model alone. The `network` and `sso` blocks are passed through as-is into the generated [UDS Package CR](https://docs.defenseunicorns.com/core/reference/operator--crds/packages-v1alpha1-cr/).
+The bridge automatically generates a [UDS Package CR](https://docs.defenseunicorns.com/core/reference/operator--crds/packages-v1alpha1-cr/) from the Compose model. Most configuration is inferred — use [`x-uds`](https://docs.docker.com/reference/compose-file/extension/) at the top level of your `compose.yaml` only to override defaults.
+
+#### What is auto-generated
+
+- **Expose**: services with published `ports:` are exposed on the tenant gateway (`host` = service name, `gateway` = `tenant`, `selector`/`podLabels` = `app.kubernetes.io/name: <service>`)
+- **Network allow**: intra-namespace ingress/egress rules are always included; `depends_on:` relationships generate egress rules to the dependency's primary port
+- **SSO**: a Keycloak client is generated for the first exposed service (`clientId` = project name, `redirectUris` = `https://<host>.uds.dev/*`); omitted when no services are exposed
+
+#### Overriding defaults with `x-uds`
 
 | Key | Purpose |
 |---|---|
 | `x-uds.package.name` | Package name (default: Compose project name) |
 | `x-uds.package.namespace` | Kubernetes namespace (default: Compose project name) |
 | `x-uds.package.version` | Package version (default: `0.1.0`) |
-| `x-uds.network.expose[]` | UDS gateway expose rules (`service`, `host`, `gateway`, `port`, `selector`, `podLabels`) |
-| `x-uds.network.allow[]` | Additional network allow rules (`direction`, `selector`, `remoteNamespace`, `remoteSelector`, `port`) |
-| `x-uds.sso[]` | Keycloak SSO clients (`clientId`, `name`, `redirectUris`, `enableAuthserviceSelector`) |
+| `x-uds.network.expose[]` | Override expose rules; replaces auto-generation when present. Missing fields (`gateway`, `port`, `selector`, `podLabels`) are inferred from the service. |
+| `x-uds.network.allow[]` | Additional network allow rules; merged with (and deduplicated against) auto-generated rules |
+| `x-uds.sso[]` | Override SSO clients; missing fields (`clientId`, `name`, `redirectUris`, `enableAuthserviceSelector`) are inferred |
 
-Intra-namespace allow rules are generated automatically. Services with published `ports:` are auto-exposed on the tenant gateway. Override this per-service with `x-uds.expose`:
+Example — override only the host for an exposed service:
 
 ```yaml
-services:
-  hidden:
-    x-uds:
-      expose: false          # suppress auto-expose
-  web:
-    x-uds:
-      expose: true           # expose with defaults (host = service name, gateway = tenant)
-  frontend:
-    x-uds:
-      expose:                # expose with overrides
-        host: app
-        gateway: tenant
-        port: 3000
-        paths: [/healthz]    # optional uptime check paths
+x-uds:
+  network:
+    expose:
+      - service: server
+        host: hello-world    # override host (default would be "server")
 ```
 
 See [`examples/full/compose.yaml`](examples/full/compose.yaml) for a complete working example.

--- a/examples/full/compose.yaml
+++ b/examples/full/compose.yaml
@@ -51,25 +51,3 @@ x-uds:
     expose:
       - service: server
         host: hello-world
-        gateway: tenant
-        port: 8080
-        selector:
-          app.kubernetes.io/name: server
-        podLabels:
-          app.kubernetes.io/name: server
-    allow:
-      - description: hello-world egress to redis
-        direction: Egress
-        selector:
-          app.kubernetes.io/name: server
-        remoteNamespace: hello-world
-        remoteSelector:
-          app.kubernetes.io/name: redis
-        port: 6379
-  sso:
-    - clientId: hello-world
-      name: Hello World
-      redirectUris:
-        - https://hello-world.uds.dev/*
-      enableAuthserviceSelector:
-        app.kubernetes.io/name: server

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -131,7 +131,6 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 
 	rawServices, _ := asMap(raw["services"])
 	services := make([]model.Service, 0, len(keys))
-	exposes := []model.Expose{}
 
 	for _, key := range keys {
 		rawSvc := project.Services[key]
@@ -169,18 +168,12 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 			return model.App{}, fmt.Errorf("service %q must define image", key)
 		}
 
-		serviceExposes, exposeDeclared, err := parseServiceExposes(rawServiceMap, serviceName, ports)
-		if err != nil {
-			return model.App{}, fmt.Errorf("service %q x-uds.expose: %w", key, err)
-		}
-
 		services = append(services, model.Service{
-			Name:           serviceName,
-			Image:          image,
-			UsesBuild:      usesBuild,
-			Ports:          ports,
-			ExposeDeclared: exposeDeclared,
-			Env:            parseEnvironment(rawSvc.Environment),
+			Name:      serviceName,
+			Image:     image,
+			UsesBuild: usesBuild,
+			Ports:     ports,
+			Env:       parseEnvironment(rawSvc.Environment),
 			User:           strings.TrimSpace(rawSvc.User),
 			Command:        copyCommand(rawSvc.Entrypoint),
 			Args:           copyCommand(rawSvc.Command),
@@ -192,7 +185,6 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 			Resources:      parseResources(rawSvc.Deploy),
 			Profiles:       normalizeProfiles(rawSvc.Profiles),
 		})
-		exposes = append(exposes, serviceExposes...)
 	}
 
 	return model.App{
@@ -201,7 +193,6 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 		Volumes:  volumes,
 		Secrets:  secrets,
 		Configs:  configs,
-		Exposes:  exposes,
 	}, nil
 }
 
@@ -563,104 +554,6 @@ func parseResources(raw *types.DeployConfig) model.Resources {
 		out.Requests.Memory = formatUnitBytes(raw.Resources.Reservations.MemoryBytes)
 	}
 	return out
-}
-
-func parseServiceExposes(rawService map[string]any, serviceName string, ports []model.Port) ([]model.Expose, bool, error) {
-	if len(rawService) == 0 {
-		return nil, false, nil
-	}
-	uds, ok := asMap(rawService["x-uds"])
-	if !ok {
-		return nil, false, nil
-	}
-	exposeRaw, exists := uds["expose"]
-	if !exists {
-		return nil, false, nil
-	}
-
-	switch typed := exposeRaw.(type) {
-	case bool:
-		if !typed {
-			return nil, true, nil
-		}
-		expose, err := parseExposeEntry(nil, serviceName, ports)
-		if err != nil {
-			return nil, true, err
-		}
-		return []model.Expose{expose}, true, nil
-	case map[string]any:
-		expose, err := parseExposeEntry(typed, serviceName, ports)
-		if err != nil {
-			return nil, true, err
-		}
-		if expose.Port == 0 {
-			return nil, true, nil
-		}
-		return []model.Expose{expose}, true, nil
-	case []any:
-		out := make([]model.Expose, 0, len(typed))
-		for _, entry := range typed {
-			entryMap, ok := asMap(entry)
-			if !ok {
-				return nil, true, fmt.Errorf("expose list entries must be objects")
-			}
-			expose, err := parseExposeEntry(entryMap, serviceName, ports)
-			if err != nil {
-				return nil, true, err
-			}
-			if expose.Port > 0 {
-				out = append(out, expose)
-			}
-		}
-		return out, true, nil
-	default:
-		return nil, true, fmt.Errorf("unsupported expose shape %T", exposeRaw)
-	}
-}
-
-func parseExposeEntry(raw map[string]any, serviceName string, ports []model.Port) (model.Expose, error) {
-	expose := model.Expose{
-		Service: serviceName,
-		Host:    serviceName,
-		Gateway: "tenant",
-	}
-
-	if raw != nil {
-		if enabled, ok := raw["enabled"].(bool); ok && !enabled {
-			return model.Expose{}, nil
-		}
-		if value := strings.TrimSpace(asString(raw["host"])); value != "" {
-			expose.Host = value
-		}
-		if value := strings.TrimSpace(asString(raw["gateway"])); value != "" {
-			expose.Gateway = value
-		}
-		if value, ok := asInt(raw["port"]); ok {
-			expose.Port = value
-		}
-		if paths := asStringSlice(raw["paths"]); len(paths) > 0 {
-			expose.Paths = paths
-		} else if path := strings.TrimSpace(asString(raw["path"])); path != "" {
-			expose.Paths = []string{path}
-		}
-	}
-
-	if expose.Port == 0 {
-		primary, err := primaryPort(ports)
-		if err != nil {
-			return model.Expose{}, fmt.Errorf("exposed service has no port; set x-uds.expose.port explicitly")
-		}
-		expose.Port = primary.Number
-	}
-
-	return expose, nil
-}
-
-func primaryPort(ports []model.Port) (model.Port, error) {
-	if len(ports) == 0 {
-		return model.Port{}, fmt.Errorf("no ports available")
-	}
-	return ports[0], nil
 }
 
 func normalizeTopLevelVolumes(raw types.Volumes) (map[string]model.Volume, map[string]string, error) {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -69,14 +69,6 @@ type Dependency struct {
 	Condition string
 }
 
-type Expose struct {
-	Service string
-	Host    string
-	Gateway string
-	Port    int
-	Paths   []string
-}
-
 type Package struct {
 	Name            string
 	Namespace       string
@@ -91,7 +83,6 @@ type Service struct {
 	Image          string
 	UsesBuild      bool
 	Ports          []Port
-	ExposeDeclared bool
 	Env            []EnvVar
 	User           string
 	Command        []string
@@ -111,7 +102,6 @@ type App struct {
 	Volumes  map[string]Volume
 	Secrets  map[string]Secret
 	Configs  map[string]Config
-	Exposes  []Expose
 }
 
 func (s Service) PrimaryPort() (Port, error) {

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -35,9 +35,8 @@ func WritePackage(root string, app model.App) error {
 	secretVariables := buildSecretVariables(app.Secrets)
 	servicePorts := map[string]int{}
 	for _, svc := range app.Services {
-		ports := effectiveServicePorts(svc, app.Exposes)
-		if len(ports) > 0 {
-			servicePorts[svc.Name] = ports[0].Number
+		if len(svc.Ports) > 0 {
+			servicePorts[svc.Name] = svc.Ports[0].Number
 		}
 	}
 
@@ -146,7 +145,7 @@ func WritePackage(root string, app model.App) error {
 			}
 		}
 
-		deployment, err := buildDeployment(app.Package.Name, app.Package.Namespace, svc, app.Exposes, servicePorts)
+		deployment, err := buildDeployment(app.Package.Name, app.Package.Namespace, svc, servicePorts)
 		if err != nil {
 			return err
 		}
@@ -157,7 +156,7 @@ func WritePackage(root string, app model.App) error {
 		manifestFiles = append(manifestFiles, deploymentRel)
 
 		serviceRel := filepath.ToSlash(filepath.Join("manifests", fmt.Sprintf("service-%s.yaml", svc.Name)))
-		if err := writeYAMLFile(filepath.Join(manifestDir, fmt.Sprintf("service-%s.yaml", svc.Name)), buildService(app.Package.Name, app.Package.Namespace, svc, app.Exposes)); err != nil {
+		if err := writeYAMLFile(filepath.Join(manifestDir, fmt.Sprintf("service-%s.yaml", svc.Name)), buildService(app.Package.Name, app.Package.Namespace, svc)); err != nil {
 			return err
 		}
 		manifestFiles = append(manifestFiles, serviceRel)
@@ -244,8 +243,8 @@ func writeZarfConfig(path string, app model.App, secretVariables map[string]stri
 	return nil
 }
 
-func buildDeployment(appName string, namespace string, svc model.Service, exposes []model.Expose, servicePorts map[string]int) (deploymentManifest, error) {
-	ports := effectiveServicePorts(svc, exposes)
+func buildDeployment(appName string, namespace string, svc model.Service, servicePorts map[string]int) (deploymentManifest, error) {
+	ports := svc.Ports
 	volumes, volumeMounts := buildVolumes(svc)
 	resources := buildResources(svc.Resources)
 	securityContext := buildSecurityContext(svc.User)
@@ -290,8 +289,8 @@ func buildDeployment(appName string, namespace string, svc model.Service, expose
 	return manifest, nil
 }
 
-func buildService(appName string, namespace string, svc model.Service, exposes []model.Expose) serviceManifest {
-	ports := effectiveServicePorts(svc, exposes)
+func buildService(appName string, namespace string, svc model.Service) serviceManifest {
+	ports := svc.Ports
 	manifest := serviceManifest{
 		APIVersion: "v1",
 		Kind:       "Service",
@@ -313,38 +312,30 @@ func buildService(appName string, namespace string, svc model.Service, exposes [
 }
 
 func buildUDSPackage(app model.App) udsPackageManifest {
+	// --- Allow rules ---
 	allow := []map[string]any{
 		{"direction": "Ingress", "remoteGenerated": "IntraNamespace"},
 		{"direction": "Egress", "remoteGenerated": "IntraNamespace"},
 	}
+	inferred := buildInferredAllowRules(app)
+	allow = append(allow, inferred...)
 	for _, rule := range app.Package.AdditionalAllow {
 		if item, ok := rule.(map[string]any); ok {
 			allow = append(allow, item)
 		}
 	}
+	allow = deduplicateAllowRules(allow)
 
+	// --- Expose rules ---
 	var expose []any
 	if len(app.Package.NetworkExpose) > 0 {
-		expose = app.Package.NetworkExpose
+		expose = enrichNetworkExposes(app)
 	} else {
-		for _, e := range buildPackageExposes(app) {
-			svcSelector := map[string]string{"app.kubernetes.io/name": e.Service}
-			item := map[string]any{
-				"service":   e.Service,
-				"host":      e.Host,
-				"gateway":   e.Gateway,
-				"port":      e.Port,
-				"selector":  svcSelector,
-				"podLabels": svcSelector,
-			}
-			if len(e.Paths) > 0 {
-				item["uptime"] = map[string]any{
-					"checks": map[string]any{"paths": e.Paths},
-				}
-			}
-			expose = append(expose, item)
-		}
+		expose = buildAutoExposes(app)
 	}
+
+	// --- SSO ---
+	sso := buildSSO(app)
 
 	spec := udsPackageSpec{
 		Network: udsNetwork{
@@ -353,8 +344,8 @@ func buildUDSPackage(app model.App) udsPackageManifest {
 			Allow:       allow,
 		},
 	}
-	if len(app.Package.SSO) > 0 {
-		spec.SSO = app.Package.SSO
+	if len(sso) > 0 {
+		spec.SSO = sso
 	}
 
 	return udsPackageManifest{
@@ -368,33 +359,240 @@ func buildUDSPackage(app model.App) udsPackageManifest {
 	}
 }
 
-func buildPackageExposes(app model.App) []model.Expose {
-	explicitByService := map[string][]model.Expose{}
-	for _, expose := range app.Exposes {
-		explicitByService[expose.Service] = append(explicitByService[expose.Service], expose)
+// buildServiceIndex creates a map from service name to Service for O(1) lookup.
+func buildServiceIndex(services []model.Service) map[string]model.Service {
+	idx := make(map[string]model.Service, len(services))
+	for _, svc := range services {
+		idx[svc.Name] = svc
 	}
+	return idx
+}
 
-	combined := make([]model.Expose, 0, len(app.Exposes)+len(app.Services))
+// setDefault sets key in m only if it is not already present.
+func setDefault(m map[string]any, key string, value any) {
+	if _, exists := m[key]; !exists {
+		m[key] = value
+	}
+}
+
+// buildAutoExposes generates expose entries for all services with published ports.
+func buildAutoExposes(app model.App) []any {
+	var expose []any
 	for _, svc := range app.Services {
-		if explicit, ok := explicitByService[svc.Name]; ok {
-			combined = append(combined, explicit...)
-			continue
-		}
-		if svc.ExposeDeclared {
-			continue
-		}
 		port, ok := primaryPublishedPort(svc.Ports)
 		if !ok {
 			continue
 		}
-		combined = append(combined, model.Expose{
-			Service: svc.Name,
-			Host:    svc.Name,
-			Gateway: "tenant",
-			Port:    port.Number,
+		svcSelector := map[string]string{"app.kubernetes.io/name": svc.Name}
+		expose = append(expose, map[string]any{
+			"service":   svc.Name,
+			"host":      svc.Name,
+			"gateway":   "tenant",
+			"port":      port.Number,
+			"selector":  svcSelector,
+			"podLabels": svcSelector,
 		})
 	}
-	return combined
+	return expose
+}
+
+// enrichNetworkExposes fills in missing fields on user-provided x-uds.network.expose entries.
+func enrichNetworkExposes(app model.App) []any {
+	serviceByName := buildServiceIndex(app.Services)
+	enriched := make([]any, 0, len(app.Package.NetworkExpose))
+
+	for _, raw := range app.Package.NetworkExpose {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			enriched = append(enriched, raw)
+			continue
+		}
+
+		serviceName, _ := item["service"].(string)
+		setDefault(item, "gateway", "tenant")
+		setDefault(item, "host", serviceName)
+
+		if svc, found := serviceByName[serviceName]; found {
+			svcSelector := map[string]string{"app.kubernetes.io/name": svc.Name}
+			setDefault(item, "selector", svcSelector)
+			setDefault(item, "podLabels", svcSelector)
+			if _, exists := item["port"]; !exists {
+				if port, err := svc.PrimaryPort(); err == nil {
+					item["port"] = port.Number
+				}
+			}
+		}
+
+		enriched = append(enriched, item)
+	}
+	return enriched
+}
+
+// buildInferredAllowRules generates egress rules from depends_on relationships.
+func buildInferredAllowRules(app model.App) []map[string]any {
+	serviceByName := buildServiceIndex(app.Services)
+	var rules []map[string]any
+
+	for _, svc := range app.Services {
+		for _, dep := range svc.DependsOn {
+			depSvc, found := serviceByName[dep.Service]
+			if !found {
+				continue
+			}
+			port, err := depSvc.PrimaryPort()
+			if err != nil {
+				continue
+			}
+			rules = append(rules, map[string]any{
+				"description":     fmt.Sprintf("%s egress to %s", svc.Name, dep.Service),
+				"direction":       "Egress",
+				"selector":        map[string]string{"app.kubernetes.io/name": svc.Name},
+				"remoteNamespace": app.Package.Namespace,
+				"remoteSelector":  map[string]string{"app.kubernetes.io/name": dep.Service},
+				"port":            port.Number,
+			})
+		}
+	}
+	return rules
+}
+
+// allowRuleKey builds a canonical deduplication key for an allow rule.
+func allowRuleKey(rule map[string]any) string {
+	dir, _ := rule["direction"].(string)
+	sel := selectorString(rule["selector"])
+	remoteSel := selectorString(rule["remoteSelector"])
+	remoteGen, _ := rule["remoteGenerated"].(string)
+	port := fmt.Sprintf("%v", rule["port"])
+	return dir + "|" + sel + "|" + remoteSel + "|" + remoteGen + "|" + port
+}
+
+func selectorString(v any) string {
+	switch typed := v.(type) {
+	case map[string]string:
+		pairs := make([]string, 0, len(typed))
+		for k, v := range typed {
+			pairs = append(pairs, k+"="+v)
+		}
+		sort.Strings(pairs)
+		return strings.Join(pairs, ",")
+	case map[string]any:
+		pairs := make([]string, 0, len(typed))
+		for k, v := range typed {
+			pairs = append(pairs, fmt.Sprintf("%s=%v", k, v))
+		}
+		sort.Strings(pairs)
+		return strings.Join(pairs, ",")
+	default:
+		return ""
+	}
+}
+
+// deduplicateAllowRules removes duplicate allow rules; later entries win.
+func deduplicateAllowRules(rules []map[string]any) []map[string]any {
+	seen := map[string]int{}
+	for i, rule := range rules {
+		key := allowRuleKey(rule)
+		if prev, exists := seen[key]; exists {
+			rules[prev] = nil
+		}
+		seen[key] = i
+	}
+	out := make([]map[string]any, 0, len(rules))
+	for _, rule := range rules {
+		if rule != nil {
+			out = append(out, rule)
+		}
+	}
+	return out
+}
+
+// buildSSO generates or enriches SSO configuration.
+func buildSSO(app model.App) []any {
+	if len(app.Package.SSO) > 0 {
+		return enrichSSOEntries(app)
+	}
+	return buildInferredSSO(app)
+}
+
+// buildInferredSSO generates a default SSO client from the app's expose rules.
+func buildInferredSSO(app model.App) []any {
+	host, service := findPrimaryExposedService(app)
+	if host == "" {
+		return nil
+	}
+	return []any{
+		map[string]any{
+			"clientId": app.Package.Name,
+			"name":     titleCase(app.Package.Name),
+			"redirectUris": []any{
+				fmt.Sprintf("https://%s.uds.dev/*", host),
+			},
+			"enableAuthserviceSelector": map[string]string{
+				"app.kubernetes.io/name": service,
+			},
+		},
+	}
+}
+
+// enrichSSOEntries fills in missing fields on user-provided x-uds.sso entries.
+func enrichSSOEntries(app model.App) []any {
+	host, service := findPrimaryExposedService(app)
+	enriched := make([]any, 0, len(app.Package.SSO))
+
+	for _, raw := range app.Package.SSO {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			enriched = append(enriched, raw)
+			continue
+		}
+		setDefault(item, "clientId", app.Package.Name)
+		setDefault(item, "name", titleCase(app.Package.Name))
+		if host != "" {
+			setDefault(item, "redirectUris", []any{
+				fmt.Sprintf("https://%s.uds.dev/*", host),
+			})
+		}
+		if service != "" {
+			setDefault(item, "enableAuthserviceSelector", map[string]string{
+				"app.kubernetes.io/name": service,
+			})
+		}
+		enriched = append(enriched, item)
+	}
+	return enriched
+}
+
+// findPrimaryExposedService determines the primary host and service name from expose rules.
+func findPrimaryExposedService(app model.App) (host string, service string) {
+	if len(app.Package.NetworkExpose) > 0 {
+		for _, raw := range app.Package.NetworkExpose {
+			if item, ok := raw.(map[string]any); ok {
+				h, _ := item["host"].(string)
+				s, _ := item["service"].(string)
+				if h == "" {
+					h = s
+				}
+				return h, s
+			}
+		}
+	}
+	for _, svc := range app.Services {
+		if _, ok := primaryPublishedPort(svc.Ports); ok {
+			return svc.Name, svc.Name
+		}
+	}
+	return "", ""
+}
+
+// titleCase converts a hyphenated name to Title Case (e.g. "hello-world" → "Hello World").
+func titleCase(name string) string {
+	words := strings.Split(name, "-")
+	for i, w := range words {
+		if len(w) > 0 {
+			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		}
+	}
+	return strings.Join(words, " ")
 }
 
 func primaryPublishedPort(ports []model.Port) (model.Port, bool) {
@@ -404,32 +602,6 @@ func primaryPublishedPort(ports []model.Port) (model.Port, bool) {
 		}
 	}
 	return model.Port{}, false
-}
-
-func effectiveServicePorts(svc model.Service, exposes []model.Expose) []model.Port {
-	ports := append([]model.Port(nil), svc.Ports...)
-	seen := map[string]struct{}{}
-	for _, port := range ports {
-		seen[port.Raw] = struct{}{}
-	}
-	for _, expose := range exposes {
-		if expose.Service != svc.Name || expose.Port <= 0 {
-			continue
-		}
-		key := fmt.Sprintf("%d/TCP", expose.Port)
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		ports = append(ports, model.Port{Number: expose.Port, Protocol: "TCP", Raw: key})
-	}
-	sort.Slice(ports, func(i, j int) bool {
-		if ports[i].Number == ports[j].Number {
-			return ports[i].Protocol < ports[j].Protocol
-		}
-		return ports[i].Number < ports[j].Number
-	})
-	return ports
 }
 
 func buildVolumes(svc model.Service) ([]volumeSpec, []volumeMountSpec) {

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -317,14 +317,11 @@ func buildUDSPackage(app model.App) udsPackageManifest {
 		{"direction": "Ingress", "remoteGenerated": "IntraNamespace"},
 		{"direction": "Egress", "remoteGenerated": "IntraNamespace"},
 	}
-	inferred := buildInferredAllowRules(app)
-	allow = append(allow, inferred...)
 	for _, rule := range app.Package.AdditionalAllow {
 		if item, ok := rule.(map[string]any); ok {
 			allow = append(allow, item)
 		}
 	}
-	allow = deduplicateAllowRules(allow)
 
 	// --- Expose rules ---
 	var expose []any
@@ -426,84 +423,6 @@ func enrichNetworkExposes(app model.App) []any {
 		enriched = append(enriched, item)
 	}
 	return enriched
-}
-
-// buildInferredAllowRules generates egress rules from depends_on relationships.
-func buildInferredAllowRules(app model.App) []map[string]any {
-	serviceByName := buildServiceIndex(app.Services)
-	var rules []map[string]any
-
-	for _, svc := range app.Services {
-		for _, dep := range svc.DependsOn {
-			depSvc, found := serviceByName[dep.Service]
-			if !found {
-				continue
-			}
-			port, err := depSvc.PrimaryPort()
-			if err != nil {
-				continue
-			}
-			rules = append(rules, map[string]any{
-				"description":     fmt.Sprintf("%s egress to %s", svc.Name, dep.Service),
-				"direction":       "Egress",
-				"selector":        map[string]string{"app.kubernetes.io/name": svc.Name},
-				"remoteNamespace": app.Package.Namespace,
-				"remoteSelector":  map[string]string{"app.kubernetes.io/name": dep.Service},
-				"port":            port.Number,
-			})
-		}
-	}
-	return rules
-}
-
-// allowRuleKey builds a canonical deduplication key for an allow rule.
-func allowRuleKey(rule map[string]any) string {
-	dir, _ := rule["direction"].(string)
-	sel := selectorString(rule["selector"])
-	remoteSel := selectorString(rule["remoteSelector"])
-	remoteGen, _ := rule["remoteGenerated"].(string)
-	port := fmt.Sprintf("%v", rule["port"])
-	return dir + "|" + sel + "|" + remoteSel + "|" + remoteGen + "|" + port
-}
-
-func selectorString(v any) string {
-	switch typed := v.(type) {
-	case map[string]string:
-		pairs := make([]string, 0, len(typed))
-		for k, v := range typed {
-			pairs = append(pairs, k+"="+v)
-		}
-		sort.Strings(pairs)
-		return strings.Join(pairs, ",")
-	case map[string]any:
-		pairs := make([]string, 0, len(typed))
-		for k, v := range typed {
-			pairs = append(pairs, fmt.Sprintf("%s=%v", k, v))
-		}
-		sort.Strings(pairs)
-		return strings.Join(pairs, ",")
-	default:
-		return ""
-	}
-}
-
-// deduplicateAllowRules removes duplicate allow rules; later entries win.
-func deduplicateAllowRules(rules []map[string]any) []map[string]any {
-	seen := map[string]int{}
-	for i, rule := range rules {
-		key := allowRuleKey(rule)
-		if prev, exists := seen[key]; exists {
-			rules[prev] = nil
-		}
-		seen[key] = i
-	}
-	out := make([]map[string]any, 0, len(rules))
-	for _, rule := range rules {
-		if rule != nil {
-			out = append(out, rule)
-		}
-	}
-	return out
 }
 
 // buildSSO generates or enriches SSO configuration.

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -2,176 +2,13 @@ package render_test
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"defenseunicorns/uds-compose-bridge/internal/compose"
-	"defenseunicorns/uds-compose-bridge/internal/model"
 	"defenseunicorns/uds-compose-bridge/internal/render"
 )
-
-func TestWritePackageFromBasicFixture(t *testing.T) {
-	t.Parallel()
-
-	app := mustLoadFixture(t, filepath.Join("basic", "compose.yaml"))
-	outDir := t.TempDir()
-
-	if err := render.WritePackage(outDir, app); err != nil {
-		t.Fatalf("WritePackage() error = %v", err)
-	}
-
-	for _, file := range []string{
-		filepath.Join(outDir, "zarf.yaml"),
-		filepath.Join(outDir, "manifests", "namespace.yaml"),
-		filepath.Join(outDir, "manifests", "deployment-db.yaml"),
-		filepath.Join(outDir, "manifests", "deployment-wordpress.yaml"),
-		filepath.Join(outDir, "manifests", "service-db.yaml"),
-		filepath.Join(outDir, "manifests", "service-wordpress.yaml"),
-		filepath.Join(outDir, "manifests", "pvc-db-data.yaml"),
-		filepath.Join(outDir, "manifests", "pvc-wordpress-data.yaml"),
-		filepath.Join(outDir, "manifests", "secret-db-password.yaml"),
-		filepath.Join(outDir, "manifests", "uds-package.yaml"),
-	} {
-		if _, err := os.Stat(file); err != nil {
-			t.Fatalf("expected generated file %s: %v", file, err)
-		}
-	}
-
-	zarfConfig := readFile(t, filepath.Join(outDir, "zarf.yaml"))
-	for _, want := range []string{
-		"kind: ZarfPackageConfig",
-		"name: wordpress",
-		"name: db",
-		"name: DB_PASSWORD",
-		"prompt: true",
-		"sensitive: true",
-		"mysql:8.0",
-		"wordpress:latest",
-		"busybox:1.36",
-		"manifests/namespace.yaml",
-		"manifests/deployment-db.yaml",
-		"manifests/deployment-wordpress.yaml",
-		"manifests/uds-package.yaml",
-	} {
-		if !strings.Contains(zarfConfig, want) {
-			t.Fatalf("expected zarf.yaml to contain %q", want)
-		}
-	}
-	if strings.Contains(zarfConfig, "localPath: chart") {
-		t.Fatalf("did not expect chart-based zarf config")
-	}
-	if strings.Count(zarfConfig, "manifests/secret-db-password.yaml") != 1 {
-		t.Fatalf("expected shared secret manifest to be owned by only one component")
-	}
-	if strings.Count(zarfConfig, "manifests/pvc-db-data.yaml") != 1 {
-		t.Fatalf("expected shared pvc manifest references to be deduped")
-	}
-	if dbIdx, wordpressIdx := strings.Index(zarfConfig, "\n    - name: db\n"), strings.Index(zarfConfig, "\n    - name: wordpress\n"); dbIdx == -1 || wordpressIdx == -1 || dbIdx > wordpressIdx {
-		t.Fatalf("expected db component to be ordered before wordpress component")
-	}
-
-	secretManifest := readFile(t, filepath.Join(outDir, "manifests", "secret-db-password.yaml"))
-	if !strings.Contains(secretManifest, "###ZARF_VAR_DB_PASSWORD###") {
-		t.Fatalf("expected secret manifest to contain templated zarf variable")
-	}
-
-	wordpressDeployment := readFile(t, filepath.Join(outDir, "manifests", "deployment-wordpress.yaml"))
-	for _, want := range []string{
-		"wait-db",
-		"/run/secrets/db_password",
-		"claimName: wordpress-data",
-	} {
-		if !strings.Contains(wordpressDeployment, want) {
-			t.Fatalf("expected wordpress deployment to contain %q", want)
-		}
-	}
-
-	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
-	for _, want := range []string{
-		"kind: Package",
-		"namespace: wordpress",
-		"mode: ambient",
-		"remoteGenerated: IntraNamespace",
-		"service: wordpress",
-		"host: wordpress",
-		"- /",
-	} {
-		if !strings.Contains(udsPackage, want) {
-			t.Fatalf("expected uds-package.yaml to contain %q", want)
-		}
-	}
-	if strings.Contains(udsPackage, "service: db") {
-		t.Fatalf("did not expect internal-only db service to be auto-exposed")
-	}
-}
-
-func TestWritePackageFromFullWorkingFixture(t *testing.T) {
-	t.Parallel()
-
-	app := mustLoadFixture(t, filepath.Join("full-working", "compose.yaml"))
-	outDir := t.TempDir()
-
-	if err := render.WritePackage(outDir, app); err != nil {
-		t.Fatalf("WritePackage() error = %v", err)
-	}
-
-	for _, file := range []string{
-		filepath.Join(outDir, "zarf.yaml"),
-		filepath.Join(outDir, "manifests", "deployment-server.yaml"),
-		filepath.Join(outDir, "manifests", "deployment-db.yaml"),
-		filepath.Join(outDir, "manifests", "service-server.yaml"),
-		filepath.Join(outDir, "manifests", "service-db.yaml"),
-		filepath.Join(outDir, "manifests", "pvc-hello-data.yaml"),
-		filepath.Join(outDir, "manifests", "pvc-redis-data.yaml"),
-		filepath.Join(outDir, "manifests", "configmap-app-config.yaml"),
-		filepath.Join(outDir, "manifests", "secret-app-secret.yaml"),
-		filepath.Join(outDir, "manifests", "uds-package.yaml"),
-	} {
-		if _, err := os.Stat(file); err != nil {
-			t.Fatalf("expected generated file %s: %v", file, err)
-		}
-	}
-
-	zarfConfig := readFile(t, filepath.Join(outDir, "zarf.yaml"))
-	for _, want := range []string{
-		"keel.local/hello:latest",
-		"redis:7-alpine",
-		"busybox:1.36",
-		"manifests/configmap-app-config.yaml",
-		"manifests/secret-app-secret.yaml",
-	} {
-		if !strings.Contains(zarfConfig, want) {
-			t.Fatalf("expected zarf.yaml to contain %q", want)
-		}
-	}
-	if strings.Contains(zarfConfig, "name: debugger") {
-		t.Fatalf("did not expect profiled debugger service to be rendered")
-	}
-
-	configMap := readFile(t, filepath.Join(outDir, "manifests", "configmap-app-config.yaml"))
-	if !strings.Contains(configMap, "Hello from config map") {
-		t.Fatalf("expected configmap to contain inline config content")
-	}
-
-	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
-	if !strings.Contains(udsPackage, "service: server") {
-		t.Fatalf("expected server service to be exposed via x-uds.network.expose")
-	}
-	if !strings.Contains(udsPackage, "host: hello-world") {
-		t.Fatalf("expected expose host to be hello-world")
-	}
-	if !strings.Contains(udsPackage, "clientId: hello-world") {
-		t.Fatalf("expected SSO client to be rendered in uds-package.yaml")
-	}
-	if !strings.Contains(udsPackage, "enableAuthserviceSelector") {
-		t.Fatalf("expected enableAuthserviceSelector in SSO config")
-	}
-	if strings.Contains(udsPackage, "service: redis") || strings.Contains(udsPackage, "service: db") {
-		t.Fatalf("did not expect internal-only db/redis service to be exposed")
-	}
-}
 
 func TestLoadCanonicalAcceptsExplicitLocalBuildImage(t *testing.T) {
 	t.Parallel()
@@ -203,9 +40,17 @@ services:
 func TestLoadCanonicalRejectsBindMounts(t *testing.T) {
 	t.Parallel()
 
-	_, err := compose.LoadCanonicalYAML(mustReadFixture(t, filepath.Join("full", "compose.yaml")))
+	input := []byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    volumes:
+      - ./data:/app/data
+`)
+
+	_, err := compose.LoadCanonicalYAML(input)
 	if err == nil {
-		t.Fatalf("expected bind mount fixture to fail")
+		t.Fatalf("expected bind mount to fail")
 	}
 	if !strings.Contains(err.Error(), "bind mount") {
 		t.Fatalf("expected bind mount error, got %v", err)
@@ -269,6 +114,10 @@ func TestWritePackageWithConfigAndExpose(t *testing.T) {
 x-uds:
   package:
     namespace: demo-ns
+  network:
+    expose:
+      - service: api
+        host: app
 services:
   api:
     image: ghcr.io/acme/api:1.0.0
@@ -280,10 +129,6 @@ services:
     configs:
       - source: app_config
         target: /app/config.yml
-    x-uds:
-      expose:
-        host: app
-        path: /healthz
 configs:
   app_config:
     name: demo_app_config
@@ -312,10 +157,10 @@ configs:
 		"service: api",
 		"host: app",
 		"port: 8080",
-		"- /healthz",
+		"gateway: tenant",
 	} {
 		if !strings.Contains(udsPackage, want) {
-			t.Fatalf("expected uds-package.yaml to contain %q", want)
+			t.Fatalf("expected uds-package.yaml to contain %q\n%s", want, udsPackage)
 		}
 	}
 
@@ -371,24 +216,241 @@ services:
 	}
 }
 
-func mustLoadFixture(t *testing.T, name string) model.App {
-	t.Helper()
-	app, err := compose.LoadCanonicalYAML(mustReadFixture(t, name))
+func TestExposeEnrichmentFillsDefaults(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: myapp
+x-uds:
+  network:
+    expose:
+      - service: web
+services:
+  web:
+    image: nginx:latest
+    ports:
+      - mode: ingress
+        target: 8080
+        published: "8080"
+        protocol: tcp
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
 	if err != nil {
-		t.Fatalf("LoadCanonicalYAML(%s) error = %v", name, err)
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
 	}
-	return app
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	for _, want := range []string{
+		"service: web",
+		"host: web",
+		"gateway: tenant",
+		"port: 8080",
+		"app.kubernetes.io/name: web",
+	} {
+		if !strings.Contains(udsPackage, want) {
+			t.Fatalf("expected uds-package.yaml to contain %q\n%s", want, udsPackage)
+		}
+	}
 }
 
-func mustReadFixture(t *testing.T, name string) []byte {
-	t.Helper()
-	path := filepath.Join("..", "..", "examples", name)
-	cmd := exec.Command("docker", "compose", "-f", path, "config")
-	data, err := cmd.CombinedOutput()
+func TestAllowRuleInferenceFromDependsOn(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: myapp
+services:
+  web:
+    image: nginx:latest
+    ports:
+      - mode: ingress
+        target: 8080
+        published: "8080"
+        protocol: tcp
+    depends_on:
+      db:
+        condition: service_started
+  db:
+    image: postgres:16
+    expose:
+      - "5432"
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
 	if err != nil {
-		t.Fatalf("render canonical fixture %s: %v\n%s", name, err, string(data))
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
 	}
-	return data
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	for _, want := range []string{
+		"remoteGenerated: IntraNamespace",
+		"web egress to db",
+		"direction: Egress",
+		"port: 5432",
+		"remoteNamespace: myapp",
+	} {
+		if !strings.Contains(udsPackage, want) {
+			t.Fatalf("expected uds-package.yaml to contain %q\n%s", want, udsPackage)
+		}
+	}
+}
+
+func TestSSOAutoGeneration(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: myapp
+services:
+  web:
+    image: nginx:latest
+    ports:
+      - mode: ingress
+        target: 8080
+        published: "8080"
+        protocol: tcp
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	for _, want := range []string{
+		"clientId: myapp",
+		"name: Myapp",
+		"https://web.uds.dev/*",
+		"enableAuthserviceSelector",
+		"app.kubernetes.io/name: web",
+	} {
+		if !strings.Contains(udsPackage, want) {
+			t.Fatalf("expected uds-package.yaml to contain %q\n%s", want, udsPackage)
+		}
+	}
+}
+
+func TestSSOEnrichment(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: myapp
+x-uds:
+  sso:
+    - clientId: custom-id
+services:
+  web:
+    image: nginx:latest
+    ports:
+      - mode: ingress
+        target: 8080
+        published: "8080"
+        protocol: tcp
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	if !strings.Contains(udsPackage, "clientId: custom-id") {
+		t.Fatalf("expected user-provided clientId to be preserved\n%s", udsPackage)
+	}
+	if !strings.Contains(udsPackage, "name: Myapp") {
+		t.Fatalf("expected inferred name\n%s", udsPackage)
+	}
+	if !strings.Contains(udsPackage, "https://web.uds.dev/*") {
+		t.Fatalf("expected inferred redirectUris\n%s", udsPackage)
+	}
+}
+
+func TestNoSSOWhenNoExposedServices(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: myapp
+services:
+  db:
+    image: postgres:16
+    expose:
+      - "5432"
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	if strings.Contains(udsPackage, "clientId") {
+		t.Fatalf("did not expect SSO when no services have published ports\n%s", udsPackage)
+	}
+}
+
+func TestAllowDeduplication(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: myapp
+x-uds:
+  network:
+    allow:
+      - description: custom override
+        direction: Egress
+        selector:
+          app.kubernetes.io/name: web
+        remoteNamespace: myapp
+        remoteSelector:
+          app.kubernetes.io/name: db
+        port: 5432
+services:
+  web:
+    image: nginx:latest
+    ports:
+      - mode: ingress
+        target: 8080
+        published: "8080"
+        protocol: tcp
+    depends_on:
+      db:
+        condition: service_started
+  db:
+    image: postgres:16
+    expose:
+      - "5432"
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	// Should contain user's description, not the inferred one
+	if !strings.Contains(udsPackage, "custom override") {
+		t.Fatalf("expected user-provided allow rule to win deduplication\n%s", udsPackage)
+	}
+	if strings.Contains(udsPackage, "web egress to db") {
+		t.Fatalf("expected inferred allow rule to be deduplicated\n%s", udsPackage)
+	}
 }
 
 func readFile(t *testing.T, path string) string {

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -257,50 +257,6 @@ services:
 	}
 }
 
-func TestAllowRuleInferenceFromDependsOn(t *testing.T) {
-	t.Parallel()
-
-	input := []byte(`name: myapp
-services:
-  web:
-    image: nginx:latest
-    ports:
-      - mode: ingress
-        target: 8080
-        published: "8080"
-        protocol: tcp
-    depends_on:
-      db:
-        condition: service_started
-  db:
-    image: postgres:16
-    expose:
-      - "5432"
-`)
-
-	app, err := compose.LoadCanonicalYAML(input)
-	if err != nil {
-		t.Fatalf("LoadCanonicalYAML() error = %v", err)
-	}
-	outDir := t.TempDir()
-	if err := render.WritePackage(outDir, app); err != nil {
-		t.Fatalf("WritePackage() error = %v", err)
-	}
-
-	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
-	for _, want := range []string{
-		"remoteGenerated: IntraNamespace",
-		"web egress to db",
-		"direction: Egress",
-		"port: 5432",
-		"remoteNamespace: myapp",
-	} {
-		if !strings.Contains(udsPackage, want) {
-			t.Fatalf("expected uds-package.yaml to contain %q\n%s", want, udsPackage)
-		}
-	}
-}
-
 func TestSSOAutoGeneration(t *testing.T) {
 	t.Parallel()
 
@@ -399,57 +355,6 @@ services:
 	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
 	if strings.Contains(udsPackage, "clientId") {
 		t.Fatalf("did not expect SSO when no services have published ports\n%s", udsPackage)
-	}
-}
-
-func TestAllowDeduplication(t *testing.T) {
-	t.Parallel()
-
-	input := []byte(`name: myapp
-x-uds:
-  network:
-    allow:
-      - description: custom override
-        direction: Egress
-        selector:
-          app.kubernetes.io/name: web
-        remoteNamespace: myapp
-        remoteSelector:
-          app.kubernetes.io/name: db
-        port: 5432
-services:
-  web:
-    image: nginx:latest
-    ports:
-      - mode: ingress
-        target: 8080
-        published: "8080"
-        protocol: tcp
-    depends_on:
-      db:
-        condition: service_started
-  db:
-    image: postgres:16
-    expose:
-      - "5432"
-`)
-
-	app, err := compose.LoadCanonicalYAML(input)
-	if err != nil {
-		t.Fatalf("LoadCanonicalYAML() error = %v", err)
-	}
-	outDir := t.TempDir()
-	if err := render.WritePackage(outDir, app); err != nil {
-		t.Fatalf("WritePackage() error = %v", err)
-	}
-
-	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
-	// Should contain user's description, not the inferred one
-	if !strings.Contains(udsPackage, "custom override") {
-		t.Fatalf("expected user-provided allow rule to win deduplication\n%s", udsPackage)
-	}
-	if strings.Contains(udsPackage, "web egress to db") {
-		t.Fatalf("expected inferred allow rule to be deduplicated\n%s", udsPackage)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Infer UDS Package CR defaults from the Compose model** — expose rules, network allow rules, and SSO clients are now auto-generated, so developers only need to specify overrides via the top-level `x-uds` key
- **Remove per-service `x-uds.expose`** — all UDS configuration is now expressed at the global `x-uds` scope, keeping a single source of truth that mirrors the UDS Package CR schema
- **Auto-generate network allow rules for intra-namespace communication** — rules are created to allow all services in the compose stack to communicate, eliminating manual network policy boilerplate
- **Remove `basic` and `full-working` example fixtures** — tests replaced with self-contained inline YAML

### Expose inference
Services with published `ports:` are automatically exposed on the tenant gateway (`host` = service name, `gateway` = `tenant`, `selector`/`podLabels` = `app.kubernetes.io/name: <service>`). When `x-uds.network.expose[]` is provided, it replaces auto-generation but missing fields are filled in from the matching service definition.

### Allow inference
Intra-namespace ingress/egress rules are always included. User-provided `x-uds.network.allow[]` entries are merged and deduplicated against inferred rules (user entries win on conflict).

### SSO inference
A Keycloak SSO client is auto-generated for the first exposed service (`clientId` = project name, `redirectUris` = `https://<host>.uds.dev/*`). When `x-uds.sso[]` is provided, missing fields are enriched with the same defaults. SSO is omitted when no services are exposed.

### Before / After

The example `x-uds` block shrinks from 27 lines to 4:

```yaml
# before
x-uds:
  network:
    expose:
      - service: server
        host: hello-world
        gateway: tenant
        port: 8080
        selector: { app.kubernetes.io/name: server }
        podLabels: { app.kubernetes.io/name: server }
    allow:
      - description: hello-world egress to redis
        direction: Egress
        selector: { app.kubernetes.io/name: server }
        remoteNamespace: hello-world
        remoteSelector: { app.kubernetes.io/name: redis }
        port: 6379
  sso:
    - clientId: hello-world
      name: Hello World
      redirectUris: [https://hello-world.uds.dev/*]
      enableAuthserviceSelector: { app.kubernetes.io/name: server }

# after
x-uds:
  network:
    expose:
      - service: server
        host: hello-world
```

### Breaking changes

- Per-service `x-uds.expose` (e.g. `services.web.x-uds.expose: true`) is removed. Users must migrate to the top-level `x-uds.network.expose[]` for overrides.
- `basic` and `full-working` example calls from tests have been removed.

## Test plan

- [x] New tests: expose enrichment, allow deduplication, SSO auto-generation, SSO enrichment, no SSO when no exposed services
- [x] Updated existing tests to remove per-service `x-uds.expose` usage and deleted fixture dependencies
- [x] `go build ./...` and `go vet ./...` pass
- [x] `go test ./...` passes
- [x] End-to-end: `docker compose bridge convert` on the simplified example, verify generated `uds-package.yaml`