### PR TITLE
feat: add ability to disable sso

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The bridge automatically generates a [UDS Package CR](https://docs.defenseunicor
 | `x-uds.package.version` | Package version (default: `0.1.0`) |
 | `x-uds.network.expose[]` | Override expose rules; replaces auto-generation when present. Missing fields (`gateway`, `port`, `selector`, `podLabels`) are inferred from the service. |
 | `x-uds.network.allow[]` | Additional network allow rules; merged with (and deduplicated against) auto-generated rules |
-| `x-uds.sso[]` | Override SSO clients; missing fields (`clientId`, `name`, `redirectUris`, `enableAuthserviceSelector`) are inferred |
+| `x-uds.sso[]` | Override SSO clients; missing fields (`clientId`, `name`, `redirectUris`, `enableAuthserviceSelector`) are inferred. Set `x-uds.sso: []` to disable inferred SSO. |
 
 Example — override only the host for an exposed service:
 
@@ -75,3 +75,5 @@ x-uds:
 ```
 
 See [`examples/full/compose.yaml`](examples/full/compose.yaml) for a complete working example.
+
+If `x-uds.sso` is omitted, the bridge infers an SSO client for the first exposed service. If `x-uds.sso` is explicitly set to an empty list, inferred SSO is disabled.

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -169,21 +169,21 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 		}
 
 		services = append(services, model.Service{
-			Name:      serviceName,
-			Image:     image,
-			UsesBuild: usesBuild,
-			Ports:     ports,
-			Env:       parseEnvironment(rawSvc.Environment),
-			User:           strings.TrimSpace(rawSvc.User),
-			Command:        copyCommand(rawSvc.Entrypoint),
-			Args:           copyCommand(rawSvc.Command),
-			Healthcheck:    parseHealthcheck(rawSvc.HealthCheck),
-			Volumes:        volumeMounts,
-			Secrets:        secretRefs,
-			Configs:        configRefs,
-			DependsOn:      dependsOn,
-			Resources:      parseResources(rawSvc.Deploy),
-			Profiles:       normalizeProfiles(rawSvc.Profiles),
+			Name:        serviceName,
+			Image:       image,
+			UsesBuild:   usesBuild,
+			Ports:       ports,
+			Env:         parseEnvironment(rawSvc.Environment),
+			User:        strings.TrimSpace(rawSvc.User),
+			Command:     copyCommand(rawSvc.Entrypoint),
+			Args:        copyCommand(rawSvc.Command),
+			Healthcheck: parseHealthcheck(rawSvc.HealthCheck),
+			Volumes:     volumeMounts,
+			Secrets:     secretRefs,
+			Configs:     configRefs,
+			DependsOn:   dependsOn,
+			Resources:   parseResources(rawSvc.Deploy),
+			Profiles:    normalizeProfiles(rawSvc.Profiles),
 		})
 	}
 
@@ -243,6 +243,7 @@ func parsePackageConfig(projectName string, raw map[string]any) (model.Package, 
 	}
 
 	if sso, ok := asSlice(rootUDS["sso"]); ok {
+		config.SSOConfigured = true
 		config.SSO = append(config.SSO, sso...)
 	}
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -75,25 +75,26 @@ type Package struct {
 	Version         string
 	NetworkExpose   []any
 	AdditionalAllow []any
+	SSOConfigured   bool
 	SSO             []any
 }
 
 type Service struct {
-	Name           string
-	Image          string
-	UsesBuild      bool
-	Ports          []Port
-	Env            []EnvVar
-	User           string
-	Command        []string
-	Args           []string
-	Healthcheck    *Healthcheck
-	Volumes        []VolumeMount
-	Secrets        []FileRef
-	Configs        []FileRef
-	DependsOn      []Dependency
-	Resources      Resources
-	Profiles       []string
+	Name        string
+	Image       string
+	UsesBuild   bool
+	Ports       []Port
+	Env         []EnvVar
+	User        string
+	Command     []string
+	Args        []string
+	Healthcheck *Healthcheck
+	Volumes     []VolumeMount
+	Secrets     []FileRef
+	Configs     []FileRef
+	DependsOn   []Dependency
+	Resources   Resources
+	Profiles    []string
 }
 
 type App struct {

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -425,9 +425,12 @@ func enrichNetworkExposes(app model.App) []any {
 	return enriched
 }
 
-// buildSSO generates or enriches SSO configuration.
+// buildSSO generates, disables, or enriches SSO configuration.
 func buildSSO(app model.App) []any {
-	if len(app.Package.SSO) > 0 {
+	if app.Package.SSOConfigured {
+		if len(app.Package.SSO) == 0 {
+			return nil
+		}
 		return enrichSSOEntries(app)
 	}
 	return buildInferredSSO(app)
@@ -1126,7 +1129,6 @@ type udsNetwork struct {
 type udsServiceMesh struct {
 	Mode string `yaml:"mode"`
 }
-
 
 type zarfPackageConfig struct {
 	APIVersion string          `yaml:"apiVersion,omitempty"`

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -294,6 +294,52 @@ services:
 	}
 }
 
+func TestExplicitEmptySSODisablesAutoGeneration(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: myapp
+x-uds:
+  network:
+    expose:
+      - service: web
+        host: app
+  sso: []
+services:
+  web:
+    image: nginx:latest
+    ports:
+      - mode: ingress
+        target: 8080
+        published: "8080"
+        protocol: tcp
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	if strings.Contains(udsPackage, "clientId:") {
+		t.Fatalf("did not expect SSO when x-uds.sso is explicitly empty\n%s", udsPackage)
+	}
+	if strings.Contains(udsPackage, "enableAuthserviceSelector") {
+		t.Fatalf("did not expect authservice selector when x-uds.sso is explicitly empty\n%s", udsPackage)
+	}
+	for _, want := range []string{
+		"service: web",
+		"host: app",
+	} {
+		if !strings.Contains(udsPackage, want) {
+			t.Fatalf("expected uds-package.yaml to contain %q\n%s", want, udsPackage)
+		}
+	}
+}
+
 func TestSSOEnrichment(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
this allows users to set: `sso: []` to disable sso while preserving it being enabled by default and allowing overrides.

```
x-uds.sso absent: infer SSO                                            
x-uds.sso: []: omit SSO                                                
x-uds.sso: [...]: overrides                              
```

