### PR TITLE
feat: added support for uds monitoring spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ zarf package deploy zarf-package-hello-world-*.tar.zst
 
 ## Compose structure
 
-The transformation maps the Compose model (as defined by the [Compose Specification](https://compose-spec.io/)) to Kubernetes resources (Deployments, Services, PVCs, ConfigMaps, Secrets) and uses `x-uds` [extension](https://docs.docker.com/reference/compose-file/extension/) keys to generate a UDS Package CR for network policy and SSO.
+The transformation maps the Compose model (as defined by the [Compose Specification](https://compose-spec.io/)) to Kubernetes resources (Deployments, Services, PVCs, ConfigMaps, Secrets) and uses `x-uds` [extension](https://docs.docker.com/reference/compose-file/extension/) keys to generate a UDS Package CR for network policy, monitoring, and SSO.
 
 ### Supported Compose configuration
 
@@ -51,6 +51,7 @@ The bridge automatically generates a [UDS Package CR](https://docs.defenseunicor
 
 - **Expose**: services with published `ports:` are exposed on the tenant gateway (`host` = service name, `gateway` = `tenant`, `selector`/`podLabels` = `app.kubernetes.io/name: <service>`)
 - **Network allow**: intra-namespace ingress/egress rules are always included, allowing all services in the namespace to communicate
+- **Monitoring**: not auto-generated; declare `x-uds.monitor[]` for metrics endpoints you want Prometheus to scrape
 - **SSO**: a Keycloak client is generated for the first exposed service (`clientId` = project name, `redirectUris` = `https://<host>.uds.dev/*`); omitted when no services are exposed
 
 #### Overriding defaults with `x-uds`
@@ -62,6 +63,7 @@ The bridge automatically generates a [UDS Package CR](https://docs.defenseunicor
 | `x-uds.package.version` | Package version (default: `0.1.0`) |
 | `x-uds.network.expose[]` | Override expose rules; replaces auto-generation when present. Missing fields (`gateway`, `port`, `selector`, `podLabels`) are inferred from the service. |
 | `x-uds.network.allow[]` | Additional network allow rules; merged with (and deduplicated against) auto-generated rules |
+| `x-uds.monitor[]` | Add monitor rules for Prometheus scraping. When `service` is set, missing `selector`, `podSelector`, `portName`, `targetPort`, `path`, and `kind` are inferred from the Compose service. |
 | `x-uds.sso[]` | Override SSO clients; missing fields (`clientId`, `name`, `redirectUris`, `enableAuthserviceSelector`) are inferred. Set `x-uds.sso: []` to disable inferred SSO. |
 
 Example — override only the host for an exposed service:
@@ -77,3 +79,5 @@ x-uds:
 See [`examples/full/compose.yaml`](examples/full/compose.yaml) for a complete working example.
 
 If `x-uds.sso` is omitted, the bridge infers an SSO client for the first exposed service. If `x-uds.sso` is explicitly set to an empty list, inferred SSO is disabled.
+
+`x-uds.monitor[]` is opt-in. Each entry may be written as a raw UDS `spec.monitor[]` item, or may use the bridge-only `service` key to infer labels and port metadata from a Compose service. For multi-port services, set either `portName` or `targetPort` so the bridge can select the intended metrics port.

--- a/examples/full/compose.yaml
+++ b/examples/full/compose.yaml
@@ -51,3 +51,7 @@ x-uds:
     expose:
       - service: server
         host: hello-world
+  monitor:
+    - service: server
+      description: Server metrics
+  # sso: []

--- a/examples/full/src/server.py
+++ b/examples/full/src/server.py
@@ -7,6 +7,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 APP_NAME = os.getenv("APP_NAME", "hello-world")
 APP_MESSAGE = os.getenv("APP_MESSAGE", "A slightly more glamorous hello")
 APP_PORT = int(os.getenv("APP_PORT", "8080"))
+REQUEST_COUNT = 0
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -21,9 +22,34 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(data)
 
+    def _metrics(self):
+        body = "\n".join(
+            [
+                "# HELP hello_world_requests_total Total HTTP requests handled by the example app.",
+                "# TYPE hello_world_requests_total counter",
+                f"hello_world_requests_total {REQUEST_COUNT}",
+                "# HELP hello_world_up Whether the example app process is running.",
+                "# TYPE hello_world_up gauge",
+                "hello_world_up 1",
+                "",
+            ]
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
     def do_GET(self):
+        global REQUEST_COUNT
+        REQUEST_COUNT += 1
+
         if self.path in ("/health", "/healthz"):
             self._json(200, {"status": "ok", "app": APP_NAME})
+            return
+
+        if self.path == "/metrics":
+            self._metrics()
             return
 
         if self.path != "/":

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -236,6 +236,9 @@ func parsePackageConfig(projectName string, raw map[string]any) (model.Package, 
 			config.AdditionalAllow = append(config.AdditionalAllow, allow...)
 		}
 	}
+	if monitor, ok := asSlice(rootUDS["monitor"]); ok {
+		config.Monitor = append(config.Monitor, monitor...)
+	}
 	if len(config.AdditionalAllow) == 0 {
 		if allow, ok := asSlice(rootUDS["allow"]); ok {
 			config.AdditionalAllow = append(config.AdditionalAllow, allow...)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -74,6 +74,7 @@ type Package struct {
 	Namespace       string
 	Version         string
 	NetworkExpose   []any
+	Monitor         []any
 	AdditionalAllow []any
 	SSOConfigured   bool
 	SSO             []any

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -177,7 +177,11 @@ func WritePackage(root string, app model.App) error {
 	}
 
 	packageRel := filepath.ToSlash(filepath.Join("manifests", "uds-package.yaml"))
-	if err := writeYAMLFile(filepath.Join(manifestDir, "uds-package.yaml"), buildUDSPackage(app)); err != nil {
+	udsPackage, err := buildUDSPackage(app)
+	if err != nil {
+		return err
+	}
+	if err := writeYAMLFile(filepath.Join(manifestDir, "uds-package.yaml"), udsPackage); err != nil {
 		return err
 	}
 	if len(ordered) > 0 {
@@ -311,7 +315,7 @@ func buildService(appName string, namespace string, svc model.Service) serviceMa
 	return manifest
 }
 
-func buildUDSPackage(app model.App) udsPackageManifest {
+func buildUDSPackage(app model.App) (udsPackageManifest, error) {
 	// --- Allow rules ---
 	allow := []map[string]any{
 		{"direction": "Ingress", "remoteGenerated": "IntraNamespace"},
@@ -333,6 +337,10 @@ func buildUDSPackage(app model.App) udsPackageManifest {
 
 	// --- SSO ---
 	sso := buildSSO(app)
+	monitor, err := buildMonitor(app)
+	if err != nil {
+		return udsPackageManifest{}, err
+	}
 
 	spec := udsPackageSpec{
 		Network: udsNetwork{
@@ -344,6 +352,9 @@ func buildUDSPackage(app model.App) udsPackageManifest {
 	if len(sso) > 0 {
 		spec.SSO = sso
 	}
+	if len(monitor) > 0 {
+		spec.Monitor = monitor
+	}
 
 	return udsPackageManifest{
 		APIVersion: "uds.dev/v1alpha1",
@@ -353,7 +364,7 @@ func buildUDSPackage(app model.App) udsPackageManifest {
 			Namespace: app.Package.Namespace,
 		},
 		Spec: spec,
-	}
+	}, nil
 }
 
 // buildServiceIndex creates a map from service name to Service for O(1) lookup.
@@ -434,6 +445,207 @@ func buildSSO(app model.App) []any {
 		return enrichSSOEntries(app)
 	}
 	return buildInferredSSO(app)
+}
+
+func buildMonitor(app model.App) ([]any, error) {
+	if len(app.Package.Monitor) == 0 {
+		return nil, nil
+	}
+
+	serviceByName := buildServiceIndex(app.Services)
+	enriched := make([]any, 0, len(app.Package.Monitor))
+
+	for _, raw := range app.Package.Monitor {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			enriched = append(enriched, raw)
+			continue
+		}
+
+		entry := cloneAnyMap(item)
+		serviceRaw, hasService := entry["service"]
+		serviceName := strings.TrimSpace(rawString(serviceRaw))
+		if !hasService {
+			enriched = append(enriched, entry)
+			continue
+		}
+		if serviceName == "" {
+			return nil, fmt.Errorf("x-uds.monitor service must be a non-empty string")
+		}
+
+		svc, found := serviceByName[serviceName]
+		if !found {
+			return nil, fmt.Errorf("x-uds.monitor service %q does not match a compose service", serviceName)
+		}
+
+		delete(entry, "service")
+		selector := serviceSelector(svc.Name)
+		setDefault(entry, "selector", selector)
+		setDefault(entry, "podSelector", selector)
+		setDefault(entry, "kind", "ServiceMonitor")
+		setDefault(entry, "path", "/metrics")
+		if err := enrichMonitorPortFields(entry, svc); err != nil {
+			return nil, fmt.Errorf("x-uds.monitor service %q: %w", serviceName, err)
+		}
+		defaultMonitorAuthorization(entry)
+
+		enriched = append(enriched, entry)
+	}
+
+	return enriched, nil
+}
+
+func enrichMonitorPortFields(entry map[string]any, svc model.Service) error {
+	ports := monitorPortsForService(svc)
+	if len(ports) == 0 {
+		return fmt.Errorf("service has no declared TCP ports for monitor inference")
+	}
+
+	portName, hasPortName := lookupRawString(entry, "portName")
+	targetPort, hasTargetPort := lookupRawInt(entry, "targetPort")
+
+	switch {
+	case hasPortName && hasTargetPort:
+		matchedByName, ok := findMonitorPortByName(ports, portName)
+		if !ok {
+			return fmt.Errorf("portName %q does not match any declared service port (%s)", portName, formatMonitorPorts(ports))
+		}
+		if matchedByName.Number != targetPort {
+			return fmt.Errorf("portName %q resolves to %d, but targetPort is %d", portName, matchedByName.Number, targetPort)
+		}
+		entry["portName"] = matchedByName.Name
+		entry["targetPort"] = matchedByName.Number
+	case hasPortName:
+		matchedByName, ok := findMonitorPortByName(ports, portName)
+		if !ok {
+			return fmt.Errorf("portName %q does not match any declared service port (%s)", portName, formatMonitorPorts(ports))
+		}
+		entry["portName"] = matchedByName.Name
+		entry["targetPort"] = matchedByName.Number
+	case hasTargetPort:
+		matchedByNumber, ok := findMonitorPortByNumber(ports, targetPort)
+		if !ok {
+			return fmt.Errorf("targetPort %d does not match any declared service port (%s)", targetPort, formatMonitorPorts(ports))
+		}
+		entry["portName"] = matchedByNumber.Name
+		entry["targetPort"] = matchedByNumber.Number
+	default:
+		if len(ports) != 1 {
+			return fmt.Errorf("service has multiple declared TCP ports; set portName or targetPort (%s)", formatMonitorPorts(ports))
+		}
+		entry["portName"] = ports[0].Name
+		entry["targetPort"] = ports[0].Number
+	}
+
+	return nil
+}
+
+func defaultMonitorAuthorization(entry map[string]any) {
+	authorization, ok := entry["authorization"].(map[string]any)
+	if !ok {
+		return
+	}
+	authorizationCopy := cloneAnyMap(authorization)
+	setDefault(authorizationCopy, "type", "Bearer")
+	entry["authorization"] = authorizationCopy
+}
+
+func cloneAnyMap(values map[string]any) map[string]any {
+	if len(values) == 0 {
+		return map[string]any{}
+	}
+	clone := make(map[string]any, len(values))
+	for key, value := range values {
+		clone[key] = value
+	}
+	return clone
+}
+
+type monitorPort struct {
+	Name   string
+	Number int
+}
+
+func monitorPortsForService(svc model.Service) []monitorPort {
+	ports := make([]monitorPort, 0, len(svc.Ports))
+	for i, port := range svc.Ports {
+		if !strings.EqualFold(port.Protocol, "TCP") {
+			continue
+		}
+		ports = append(ports, monitorPort{
+			Name:   buildPortName(i, port),
+			Number: port.Number,
+		})
+	}
+	return ports
+}
+
+func findMonitorPortByName(ports []monitorPort, name string) (monitorPort, bool) {
+	for _, port := range ports {
+		if port.Name == name {
+			return port, true
+		}
+	}
+	return monitorPort{}, false
+}
+
+func findMonitorPortByNumber(ports []monitorPort, number int) (monitorPort, bool) {
+	for _, port := range ports {
+		if port.Number == number {
+			return port, true
+		}
+	}
+	return monitorPort{}, false
+}
+
+func formatMonitorPorts(ports []monitorPort) string {
+	values := make([]string, 0, len(ports))
+	for _, port := range ports {
+		values = append(values, fmt.Sprintf("%s=%d", port.Name, port.Number))
+	}
+	return strings.Join(values, ", ")
+}
+
+func lookupRawString(values map[string]any, key string) (string, bool) {
+	raw, exists := values[key]
+	if !exists {
+		return "", false
+	}
+	text := strings.TrimSpace(rawString(raw))
+	if text == "" {
+		return "", false
+	}
+	return text, true
+}
+
+func rawString(value any) string {
+	text, _ := value.(string)
+	return text
+}
+
+func lookupRawInt(values map[string]any, key string) (int, bool) {
+	raw, exists := values[key]
+	if !exists {
+		return 0, false
+	}
+	switch typed := raw.(type) {
+	case int:
+		return typed, true
+	case int64:
+		return int(typed), true
+	case uint64:
+		return int(typed), true
+	case float64:
+		return int(typed), true
+	case string:
+		parsed, err := strconv.Atoi(strings.TrimSpace(typed))
+		if err != nil {
+			return 0, false
+		}
+		return parsed, true
+	default:
+		return 0, false
+	}
 }
 
 // buildInferredSSO generates a default SSO client from the app's expose rules.
@@ -1117,6 +1329,7 @@ type udsPackageManifest struct {
 
 type udsPackageSpec struct {
 	Network udsNetwork `yaml:"network"`
+	Monitor []any      `yaml:"monitor,omitempty"`
 	SSO     []any      `yaml:"sso,omitempty"`
 }
 

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -404,6 +404,269 @@ services:
 	}
 }
 
+func TestMonitorEnrichment(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: metrics-demo
+x-uds:
+  monitor:
+    - service: api
+      description: API metrics
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    expose:
+      - "9090"
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	for _, want := range []string{
+		"monitor:",
+		"description: API metrics",
+		"selector:",
+		"podSelector:",
+		"app.kubernetes.io/name: api",
+		"portName: http",
+		"targetPort: 9090",
+		"path: /metrics",
+		"kind: ServiceMonitor",
+	} {
+		if !strings.Contains(udsPackage, want) {
+			t.Fatalf("expected uds-package.yaml to contain %q\n%s", want, udsPackage)
+		}
+	}
+	if strings.Contains(udsPackage, "service: api") {
+		t.Fatalf("did not expect bridge-only service field in rendered monitor\n%s", udsPackage)
+	}
+}
+
+func TestMonitorAuthorizationDefaultsAndExplicitFields(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: metrics-demo
+x-uds:
+  monitor:
+    - service: api
+      kind: PodMonitor
+      path: /custom/metrics
+      authorization:
+        credentials:
+          name: metrics-auth-secret
+          key: token
+          optional: false
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    expose:
+      - "9090"
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	for _, want := range []string{
+		"kind: PodMonitor",
+		"path: /custom/metrics",
+		"portName: http",
+		"targetPort: 9090",
+		"authorization:",
+		"type: Bearer",
+		"name: metrics-auth-secret",
+		"key: token",
+		"optional: false",
+	} {
+		if !strings.Contains(udsPackage, want) {
+			t.Fatalf("expected uds-package.yaml to contain %q\n%s", want, udsPackage)
+		}
+	}
+}
+
+func TestMonitorResolvesPortNameFromTargetPort(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: metrics-demo
+x-uds:
+  monitor:
+    - service: api
+      targetPort: 9090
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    expose:
+      - "8080"
+      - "9090"
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	for _, want := range []string{
+		"targetPort: 9090",
+		"portName: port-9090-tcp",
+	} {
+		if !strings.Contains(udsPackage, want) {
+			t.Fatalf("expected uds-package.yaml to contain %q\n%s", want, udsPackage)
+		}
+	}
+}
+
+func TestMonitorPassthroughWithoutService(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: metrics-demo
+x-uds:
+  monitor:
+    - selector:
+        app: api
+      podSelector:
+        app: api
+      portName: metrics
+      targetPort: 9090
+      path: /stats/metrics
+      kind: PodMonitor
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    expose:
+      - "9090"
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	for _, want := range []string{
+		"selector:",
+		"podSelector:",
+		"app: api",
+		"portName: metrics",
+		"targetPort: 9090",
+		"path: /stats/metrics",
+		"kind: PodMonitor",
+	} {
+		if !strings.Contains(udsPackage, want) {
+			t.Fatalf("expected uds-package.yaml to contain %q\n%s", want, udsPackage)
+		}
+	}
+}
+
+func TestMonitorRejectsAmbiguousServicePorts(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: metrics-demo
+x-uds:
+  monitor:
+    - service: api
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    expose:
+      - "8080"
+      - "9090"
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	err = render.WritePackage(outDir, app)
+	if err == nil {
+		t.Fatalf("expected WritePackage() to fail for ambiguous monitor ports")
+	}
+	if !strings.Contains(err.Error(), "multiple declared TCP ports") {
+		t.Fatalf("expected ambiguous port error, got %v", err)
+	}
+}
+
+func TestMonitorRejectsUnknownService(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: metrics-demo
+x-uds:
+  monitor:
+    - service: missing
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    expose:
+      - "9090"
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	err = render.WritePackage(outDir, app)
+	if err == nil {
+		t.Fatalf("expected WritePackage() to fail for unknown monitor service")
+	}
+	if !strings.Contains(err.Error(), `x-uds.monitor service "missing"`) {
+		t.Fatalf("expected unknown service error, got %v", err)
+	}
+}
+
+func TestMonitorRejectsMismatchedPortNameAndTargetPort(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: metrics-demo
+x-uds:
+  monitor:
+    - service: api
+      portName: http
+      targetPort: 9090
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    expose:
+      - "8080"
+      - "9090"
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	err = render.WritePackage(outDir, app)
+	if err == nil {
+		t.Fatalf("expected WritePackage() to fail for mismatched monitor port fields")
+	}
+	if !strings.Contains(err.Error(), `portName "http" resolves to 8080, but targetPort is 9090`) {
+		t.Fatalf("expected mismatched port error, got %v", err)
+	}
+}
+
 func readFile(t *testing.T, path string) string {
 	t.Helper()
 	data, err := os.ReadFile(path)


### PR DESCRIPTION
## Summary                                                                 

- add support for top-level `x-uds.monitor[]` and render it into `spec.    
monitor[]` in the generated `uds-package.yaml`                             
- support a bridge-friendly `service` field that infers `selector`,        
`podSelector`, `portName`, `targetPort`, `path`, and default `kind`        
from the Compose service                                                   
- add validation and tests for monitor enrichment, passthrough             
behavior, and invalid multi-port/unknown-service cases                     
- update the example app and docs to demonstrate monitor support with      
a real `/metrics` endpoint                                                 

## Details                                                                 

This change extends the existing Compose -> UDS Package flow to            
support the UDS Package `monitor` section.                                 

Monitor entries can now be authored in two ways:                           

1. As raw UDS `spec.monitor[]` entries, which are passed through           
unchanged                                                                  
2. As enriched bridge entries using a `service` key, which lets the        
bridge infer the Kubernetes labels and service port metadata from the      
Compose model                                                              

Behavior for enriched monitor entries:                                     
- defaults `kind` to `ServiceMonitor`                                      
- defaults `path` to `/metrics`                                            
- defaults `selector` and `podSelector` to `app.kubernetes.io/name:        
<service>`                                                                 
- infers `portName` and `targetPort` from the Compose service              
- defaults `authorization.type` to `Bearer` when an authorization          
block is present                                                           

Validation is intentionally strict for ambiguous cases:                    
- unknown `service` references fail                                        
- multi-port services require `portName` or `targetPort`                   
- mismatched `portName` and `targetPort` fail                              

This remains opt-in: monitors are not auto-generated from Compose          
ports.                                                                     

## Example                                                                 

The `examples/full` app now includes:                                      
- `x-uds.monitor[]` in `compose.yaml`                                      
- a real `/metrics` endpoint in the sample server                          
