### PR TITLE
feat: added support for uds cabundle spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ The bridge automatically generates a [UDS Package CR](https://docs.defenseunicor
 | `x-uds.monitor[]` | Add monitor rules for Prometheus scraping. When `service` is set, missing `selector`, `podSelector`, `portName`, `targetPort`, `path`, and `kind` are inferred from the Compose service. |
 | `x-uds.sso[]` | Override SSO clients; missing fields (`clientId`, `name`, `redirectUris`, `enableAuthserviceSelector`) are inferred. Set `x-uds.sso: []` to disable inferred SSO. |
 | `x-uds.caBundle.configMap` | Customize the operator-managed trust bundle ConfigMap metadata for this package namespace. This renders to `spec.caBundle` in `manifests/uds-package.yaml`. |
-| `x-uds.caBundle.CA_BUNDLE_*` | Set UDS Core trust-bundle source variables. These render to `out/uds-config.yaml`, not to the Package CR. |
 
 Example — override only the host for an exposed service:
 
@@ -84,4 +83,4 @@ If `x-uds.sso` is omitted, the bridge infers an SSO client for the first exposed
 
 `x-uds.monitor[]` is opt-in. Each entry may be written as a raw UDS `spec.monitor[]` item, or may use the bridge-only `service` key to infer labels and port metadata from a Compose service. For multi-port services, set either `portName` or `targetPort` so the bridge can select the intended metrics port.
 
-`x-uds.caBundle` is split on output. `configMap` customizes the namespace trust-bundle `ConfigMap` created by UDS Core for this package, while `CA_BUNDLE_CERTS`, `CA_BUNDLE_INCLUDE_DOD_CERTS`, and `CA_BUNDLE_INCLUDE_PUBLIC_CERTS` render to a helper `uds-config.yaml` under `variables.core`. `CA_BUNDLE_CERTS` must be supplied as a base64-encoded PEM bundle, matching the UDS Core documentation.
+`x-uds.caBundle.configMap` customizes the namespace trust-bundle `ConfigMap` created by UDS Core for this package. The actual trust bundle contents are configured separately in UDS Core and are not part of the Package CR.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ zarf package deploy zarf-package-hello-world-*.tar.zst
 
 ## Compose structure
 
-The transformation maps the Compose model (as defined by the [Compose Specification](https://compose-spec.io/)) to Kubernetes resources (Deployments, Services, PVCs, ConfigMaps, Secrets) and uses `x-uds` [extension](https://docs.docker.com/reference/compose-file/extension/) keys to generate a UDS Package CR for network policy, monitoring, and SSO.
+The transformation maps the Compose model (as defined by the [Compose Specification](https://compose-spec.io/)) to Kubernetes resources (Deployments, Services, PVCs, ConfigMaps, Secrets) and uses `x-uds` [extension](https://docs.docker.com/reference/compose-file/extension/) keys to generate a UDS Package CR for network policy, monitoring, SSO, and trust-bundle distribution.
 
 ### Supported Compose configuration
 
@@ -65,6 +65,8 @@ The bridge automatically generates a [UDS Package CR](https://docs.defenseunicor
 | `x-uds.network.allow[]` | Additional network allow rules; merged with (and deduplicated against) auto-generated rules |
 | `x-uds.monitor[]` | Add monitor rules for Prometheus scraping. When `service` is set, missing `selector`, `podSelector`, `portName`, `targetPort`, `path`, and `kind` are inferred from the Compose service. |
 | `x-uds.sso[]` | Override SSO clients; missing fields (`clientId`, `name`, `redirectUris`, `enableAuthserviceSelector`) are inferred. Set `x-uds.sso: []` to disable inferred SSO. |
+| `x-uds.caBundle.configMap` | Customize the operator-managed trust bundle ConfigMap metadata for this package namespace. This renders to `spec.caBundle` in `manifests/uds-package.yaml`. |
+| `x-uds.caBundle.CA_BUNDLE_*` | Set UDS Core trust-bundle source variables. These render to `out/uds-config.yaml`, not to the Package CR. |
 
 Example — override only the host for an exposed service:
 
@@ -81,3 +83,5 @@ See [`examples/full/compose.yaml`](examples/full/compose.yaml) for a complete wo
 If `x-uds.sso` is omitted, the bridge infers an SSO client for the first exposed service. If `x-uds.sso` is explicitly set to an empty list, inferred SSO is disabled.
 
 `x-uds.monitor[]` is opt-in. Each entry may be written as a raw UDS `spec.monitor[]` item, or may use the bridge-only `service` key to infer labels and port metadata from a Compose service. For multi-port services, set either `portName` or `targetPort` so the bridge can select the intended metrics port.
+
+`x-uds.caBundle` is split on output. `configMap` customizes the namespace trust-bundle `ConfigMap` created by UDS Core for this package, while `CA_BUNDLE_CERTS`, `CA_BUNDLE_INCLUDE_DOD_CERTS`, and `CA_BUNDLE_INCLUDE_PUBLIC_CERTS` render to a helper `uds-config.yaml` under `variables.core`. `CA_BUNDLE_CERTS` must be supplied as a base64-encoded PEM bundle, matching the UDS Core documentation.

--- a/examples/full/compose.yaml
+++ b/examples/full/compose.yaml
@@ -60,7 +60,4 @@ x-uds:
   #     key: ca-bundle.pem
   #     labels:
   #       uds.dev/pod-reload: "true"
-  #   CA_BUNDLE_CERTS: <base64-pem-bundle>
-  #   CA_BUNDLE_INCLUDE_DOD_CERTS: true
-  #   CA_BUNDLE_INCLUDE_PUBLIC_CERTS: true
   # sso: []

--- a/examples/full/compose.yaml
+++ b/examples/full/compose.yaml
@@ -54,4 +54,13 @@ x-uds:
   monitor:
     - service: server
       description: Server metrics
+  # caBundle:
+  #   configMap:
+  #     name: uds-trust-bundle
+  #     key: ca-bundle.pem
+  #     labels:
+  #       uds.dev/pod-reload: "true"
+  #   CA_BUNDLE_CERTS: <base64-pem-bundle>
+  #   CA_BUNDLE_INCLUDE_DOD_CERTS: true
+  #   CA_BUNDLE_INCLUDE_PUBLIC_CERTS: true
   # sso: []

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -95,7 +95,7 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 		return model.App{}, fmt.Errorf("invalid compose project name: %w", err)
 	}
 
-	packageCfg, coreCfg, err := parsePackageConfig(projectName, raw)
+	packageCfg, err := parsePackageConfig(projectName, raw)
 	if err != nil {
 		return model.App{}, err
 	}
@@ -189,7 +189,6 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 
 	return model.App{
 		Package:  packageCfg,
-		Core:     coreCfg,
 		Services: services,
 		Volumes:  volumes,
 		Secrets:  secrets,
@@ -197,31 +196,30 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 	}, nil
 }
 
-func parsePackageConfig(projectName string, raw map[string]any) (model.Package, model.Core, error) {
+func parsePackageConfig(projectName string, raw map[string]any) (model.Package, error) {
 	config := model.Package{
 		Name:      projectName,
 		Namespace: projectName,
 		Version:   model.DefaultVersion,
 	}
-	core := model.Core{}
 
 	rootUDS, ok := asMap(raw["x-uds"])
 	if !ok {
-		return config, core, nil
+		return config, nil
 	}
 
 	if pkg, ok := asMap(rootUDS["package"]); ok {
 		if value := strings.TrimSpace(asString(pkg["name"])); value != "" {
 			normalized, err := normalizeName(value)
 			if err != nil {
-				return model.Package{}, model.Core{}, fmt.Errorf("invalid x-uds.package.name: %w", err)
+				return model.Package{}, fmt.Errorf("invalid x-uds.package.name: %w", err)
 			}
 			config.Name = normalized
 		}
 		if value := strings.TrimSpace(asString(pkg["namespace"])); value != "" {
 			normalized, err := normalizeName(value)
 			if err != nil {
-				return model.Package{}, model.Core{}, fmt.Errorf("invalid x-uds.package.namespace: %w", err)
+				return model.Package{}, fmt.Errorf("invalid x-uds.package.namespace: %w", err)
 			}
 			config.Namespace = normalized
 		}
@@ -255,60 +253,68 @@ func parsePackageConfig(projectName string, raw map[string]any) (model.Package, 
 	if rawCABundle, exists := rootUDS["caBundle"]; exists {
 		caBundle, ok := asMap(rawCABundle)
 		if !ok {
-			return model.Package{}, model.Core{}, fmt.Errorf("invalid x-uds.caBundle: must be an object")
+			return model.Package{}, fmt.Errorf("invalid x-uds.caBundle: must be an object")
 		}
 
-		packageCABundle := map[string]any{}
 		for key, value := range caBundle {
-			switch key {
-			case "CA_BUNDLE_CERTS":
-				certs, ok := value.(string)
-				if !ok || strings.TrimSpace(certs) == "" {
-					return model.Package{}, model.Core{}, fmt.Errorf("invalid x-uds.caBundle.CA_BUNDLE_CERTS: must be a non-empty string")
-				}
-				core.CABundleCerts = strings.TrimSpace(certs)
-			case "CA_BUNDLE_INCLUDE_DOD_CERTS":
-				parsed, err := parseStringBool(value)
-				if err != nil {
-					return model.Package{}, model.Core{}, fmt.Errorf("invalid x-uds.caBundle.CA_BUNDLE_INCLUDE_DOD_CERTS: %w", err)
-				}
-				core.CABundleIncludeDoDCerts = &parsed
-			case "CA_BUNDLE_INCLUDE_PUBLIC_CERTS":
-				parsed, err := parseStringBool(value)
-				if err != nil {
-					return model.Package{}, model.Core{}, fmt.Errorf("invalid x-uds.caBundle.CA_BUNDLE_INCLUDE_PUBLIC_CERTS: %w", err)
-				}
-				core.CABundleIncludePublicCerts = &parsed
-			case "configMap":
-				if _, ok := asMap(value); !ok {
-					return model.Package{}, model.Core{}, fmt.Errorf("invalid x-uds.caBundle.configMap: must be an object")
-				}
-				packageCABundle[key] = value
-			default:
-				packageCABundle[key] = value
+			if key != "configMap" {
+				return model.Package{}, fmt.Errorf("invalid x-uds.caBundle.%s: unsupported field", key)
 			}
-		}
-		if len(packageCABundle) > 0 {
-			config.CABundle = packageCABundle
+			configMap, err := normalizeCABundleConfigMap(value)
+			if err != nil {
+				return model.Package{}, err
+			}
+			config.CABundle = map[string]any{"configMap": configMap}
 		}
 	}
 
-	return config, core, nil
+	return config, nil
 }
 
-func parseStringBool(value any) (bool, error) {
-	switch typed := value.(type) {
-	case bool:
-		return typed, nil
-	case string:
-		parsed, err := strconv.ParseBool(strings.TrimSpace(typed))
-		if err != nil {
-			return false, fmt.Errorf("must be a boolean")
-		}
-		return parsed, nil
-	default:
-		return false, fmt.Errorf("must be a boolean")
+func normalizeCABundleConfigMap(value any) (map[string]any, error) {
+	configMap, ok := asMap(value)
+	if !ok {
+		return nil, fmt.Errorf("invalid x-uds.caBundle.configMap: must be an object")
 	}
+
+	normalized := map[string]any{}
+	for key, raw := range configMap {
+		switch key {
+		case "name", "key":
+			value := strings.TrimSpace(asString(raw))
+			if value == "" {
+				return nil, fmt.Errorf("invalid x-uds.caBundle.configMap.%s: must be a non-empty string", key)
+			}
+			normalized[key] = value
+		case "labels", "annotations":
+			value, err := normalizeStringMap(raw, fmt.Sprintf("x-uds.caBundle.configMap.%s", key))
+			if err != nil {
+				return nil, err
+			}
+			normalized[key] = value
+		default:
+			return nil, fmt.Errorf("invalid x-uds.caBundle.configMap.%s: unsupported field", key)
+		}
+	}
+
+	return normalized, nil
+}
+
+func normalizeStringMap(value any, field string) (map[string]string, error) {
+	items, ok := asMap(value)
+	if !ok {
+		return nil, fmt.Errorf("invalid %s: must be an object", field)
+	}
+
+	normalized := make(map[string]string, len(items))
+	for key, raw := range items {
+		text, ok := raw.(string)
+		if !ok {
+			return nil, fmt.Errorf("invalid %s.%s: must be a string", field, key)
+		}
+		normalized[key] = text
+	}
+	return normalized, nil
 }
 
 func validateBuildImage(serviceName string, image string, rawService map[string]any) error {

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -95,7 +95,7 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 		return model.App{}, fmt.Errorf("invalid compose project name: %w", err)
 	}
 
-	packageCfg, err := parsePackageConfig(projectName, raw)
+	packageCfg, coreCfg, err := parsePackageConfig(projectName, raw)
 	if err != nil {
 		return model.App{}, err
 	}
@@ -189,6 +189,7 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 
 	return model.App{
 		Package:  packageCfg,
+		Core:     coreCfg,
 		Services: services,
 		Volumes:  volumes,
 		Secrets:  secrets,
@@ -196,30 +197,31 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 	}, nil
 }
 
-func parsePackageConfig(projectName string, raw map[string]any) (model.Package, error) {
+func parsePackageConfig(projectName string, raw map[string]any) (model.Package, model.Core, error) {
 	config := model.Package{
 		Name:      projectName,
 		Namespace: projectName,
 		Version:   model.DefaultVersion,
 	}
+	core := model.Core{}
 
 	rootUDS, ok := asMap(raw["x-uds"])
 	if !ok {
-		return config, nil
+		return config, core, nil
 	}
 
 	if pkg, ok := asMap(rootUDS["package"]); ok {
 		if value := strings.TrimSpace(asString(pkg["name"])); value != "" {
 			normalized, err := normalizeName(value)
 			if err != nil {
-				return model.Package{}, fmt.Errorf("invalid x-uds.package.name: %w", err)
+				return model.Package{}, model.Core{}, fmt.Errorf("invalid x-uds.package.name: %w", err)
 			}
 			config.Name = normalized
 		}
 		if value := strings.TrimSpace(asString(pkg["namespace"])); value != "" {
 			normalized, err := normalizeName(value)
 			if err != nil {
-				return model.Package{}, fmt.Errorf("invalid x-uds.package.namespace: %w", err)
+				return model.Package{}, model.Core{}, fmt.Errorf("invalid x-uds.package.namespace: %w", err)
 			}
 			config.Namespace = normalized
 		}
@@ -250,7 +252,63 @@ func parsePackageConfig(projectName string, raw map[string]any) (model.Package, 
 		config.SSO = append(config.SSO, sso...)
 	}
 
-	return config, nil
+	if rawCABundle, exists := rootUDS["caBundle"]; exists {
+		caBundle, ok := asMap(rawCABundle)
+		if !ok {
+			return model.Package{}, model.Core{}, fmt.Errorf("invalid x-uds.caBundle: must be an object")
+		}
+
+		packageCABundle := map[string]any{}
+		for key, value := range caBundle {
+			switch key {
+			case "CA_BUNDLE_CERTS":
+				certs, ok := value.(string)
+				if !ok || strings.TrimSpace(certs) == "" {
+					return model.Package{}, model.Core{}, fmt.Errorf("invalid x-uds.caBundle.CA_BUNDLE_CERTS: must be a non-empty string")
+				}
+				core.CABundleCerts = strings.TrimSpace(certs)
+			case "CA_BUNDLE_INCLUDE_DOD_CERTS":
+				parsed, err := parseStringBool(value)
+				if err != nil {
+					return model.Package{}, model.Core{}, fmt.Errorf("invalid x-uds.caBundle.CA_BUNDLE_INCLUDE_DOD_CERTS: %w", err)
+				}
+				core.CABundleIncludeDoDCerts = &parsed
+			case "CA_BUNDLE_INCLUDE_PUBLIC_CERTS":
+				parsed, err := parseStringBool(value)
+				if err != nil {
+					return model.Package{}, model.Core{}, fmt.Errorf("invalid x-uds.caBundle.CA_BUNDLE_INCLUDE_PUBLIC_CERTS: %w", err)
+				}
+				core.CABundleIncludePublicCerts = &parsed
+			case "configMap":
+				if _, ok := asMap(value); !ok {
+					return model.Package{}, model.Core{}, fmt.Errorf("invalid x-uds.caBundle.configMap: must be an object")
+				}
+				packageCABundle[key] = value
+			default:
+				packageCABundle[key] = value
+			}
+		}
+		if len(packageCABundle) > 0 {
+			config.CABundle = packageCABundle
+		}
+	}
+
+	return config, core, nil
+}
+
+func parseStringBool(value any) (bool, error) {
+	switch typed := value.(type) {
+	case bool:
+		return typed, nil
+	case string:
+		parsed, err := strconv.ParseBool(strings.TrimSpace(typed))
+		if err != nil {
+			return false, fmt.Errorf("must be a boolean")
+		}
+		return parsed, nil
+	default:
+		return false, fmt.Errorf("must be a boolean")
+	}
 }
 
 func validateBuildImage(serviceName string, image string, rawService map[string]any) error {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -81,12 +81,6 @@ type Package struct {
 	CABundle        map[string]any
 }
 
-type Core struct {
-	CABundleCerts              string
-	CABundleIncludeDoDCerts    *bool
-	CABundleIncludePublicCerts *bool
-}
-
 type Service struct {
 	Name        string
 	Image       string
@@ -107,7 +101,6 @@ type Service struct {
 
 type App struct {
 	Package  Package
-	Core     Core
 	Services []Service
 	Volumes  map[string]Volume
 	Secrets  map[string]Secret

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -78,6 +78,13 @@ type Package struct {
 	AdditionalAllow []any
 	SSOConfigured   bool
 	SSO             []any
+	CABundle        map[string]any
+}
+
+type Core struct {
+	CABundleCerts              string
+	CABundleIncludeDoDCerts    *bool
+	CABundleIncludePublicCerts *bool
 }
 
 type Service struct {
@@ -100,6 +107,7 @@ type Service struct {
 
 type App struct {
 	Package  Package
+	Core     Core
 	Services []Service
 	Volumes  map[string]Volume
 	Secrets  map[string]Secret

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -194,9 +194,6 @@ func WritePackage(root string, app model.App) error {
 	if err := writeZarfConfig(filepath.Join(root, "zarf.yaml"), app, secretVariables, ordered); err != nil {
 		return err
 	}
-	if err := writeUDSConfig(filepath.Join(root, "uds-config.yaml"), app.Core); err != nil {
-		return err
-	}
 
 	return nil
 }
@@ -1348,46 +1345,6 @@ type udsNetwork struct {
 
 type udsServiceMesh struct {
 	Mode string `yaml:"mode"`
-}
-
-type udsConfig struct {
-	Variables udsConfigVariables `yaml:"variables,omitempty"`
-}
-
-type udsConfigVariables struct {
-	Core udsCoreVariables `yaml:"core,omitempty"`
-}
-
-type udsCoreVariables struct {
-	CABundleCerts              string `yaml:"CA_BUNDLE_CERTS,omitempty"`
-	CABundleIncludeDoDCerts    string `yaml:"CA_BUNDLE_INCLUDE_DOD_CERTS,omitempty"`
-	CABundleIncludePublicCerts string `yaml:"CA_BUNDLE_INCLUDE_PUBLIC_CERTS,omitempty"`
-}
-
-func writeUDSConfig(path string, core model.Core) error {
-	if !hasCoreVariables(core) {
-		return nil
-	}
-
-	config := udsConfig{
-		Variables: udsConfigVariables{
-			Core: udsCoreVariables{
-				CABundleCerts: core.CABundleCerts,
-			},
-		},
-	}
-	if core.CABundleIncludeDoDCerts != nil {
-		config.Variables.Core.CABundleIncludeDoDCerts = strconv.FormatBool(*core.CABundleIncludeDoDCerts)
-	}
-	if core.CABundleIncludePublicCerts != nil {
-		config.Variables.Core.CABundleIncludePublicCerts = strconv.FormatBool(*core.CABundleIncludePublicCerts)
-	}
-
-	return writeYAMLFile(path, config)
-}
-
-func hasCoreVariables(core model.Core) bool {
-	return strings.TrimSpace(core.CABundleCerts) != "" || core.CABundleIncludeDoDCerts != nil || core.CABundleIncludePublicCerts != nil
 }
 
 type zarfPackageConfig struct {

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -194,6 +194,9 @@ func WritePackage(root string, app model.App) error {
 	if err := writeZarfConfig(filepath.Join(root, "zarf.yaml"), app, secretVariables, ordered); err != nil {
 		return err
 	}
+	if err := writeUDSConfig(filepath.Join(root, "uds-config.yaml"), app.Core); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -348,6 +351,9 @@ func buildUDSPackage(app model.App) (udsPackageManifest, error) {
 			Expose:      expose,
 			Allow:       allow,
 		},
+	}
+	if len(app.Package.CABundle) > 0 {
+		spec.CABundle = app.Package.CABundle
 	}
 	if len(sso) > 0 {
 		spec.SSO = sso
@@ -1328,9 +1334,10 @@ type udsPackageManifest struct {
 }
 
 type udsPackageSpec struct {
-	Network udsNetwork `yaml:"network"`
-	Monitor []any      `yaml:"monitor,omitempty"`
-	SSO     []any      `yaml:"sso,omitempty"`
+	Network  udsNetwork     `yaml:"network"`
+	Monitor  []any          `yaml:"monitor,omitempty"`
+	SSO      []any          `yaml:"sso,omitempty"`
+	CABundle map[string]any `yaml:"caBundle,omitempty"`
 }
 
 type udsNetwork struct {
@@ -1341,6 +1348,46 @@ type udsNetwork struct {
 
 type udsServiceMesh struct {
 	Mode string `yaml:"mode"`
+}
+
+type udsConfig struct {
+	Variables udsConfigVariables `yaml:"variables,omitempty"`
+}
+
+type udsConfigVariables struct {
+	Core udsCoreVariables `yaml:"core,omitempty"`
+}
+
+type udsCoreVariables struct {
+	CABundleCerts              string `yaml:"CA_BUNDLE_CERTS,omitempty"`
+	CABundleIncludeDoDCerts    string `yaml:"CA_BUNDLE_INCLUDE_DOD_CERTS,omitempty"`
+	CABundleIncludePublicCerts string `yaml:"CA_BUNDLE_INCLUDE_PUBLIC_CERTS,omitempty"`
+}
+
+func writeUDSConfig(path string, core model.Core) error {
+	if !hasCoreVariables(core) {
+		return nil
+	}
+
+	config := udsConfig{
+		Variables: udsConfigVariables{
+			Core: udsCoreVariables{
+				CABundleCerts: core.CABundleCerts,
+			},
+		},
+	}
+	if core.CABundleIncludeDoDCerts != nil {
+		config.Variables.Core.CABundleIncludeDoDCerts = strconv.FormatBool(*core.CABundleIncludeDoDCerts)
+	}
+	if core.CABundleIncludePublicCerts != nil {
+		config.Variables.Core.CABundleIncludePublicCerts = strconv.FormatBool(*core.CABundleIncludePublicCerts)
+	}
+
+	return writeYAMLFile(path, config)
+}
+
+func hasCoreVariables(core model.Core) bool {
+	return strings.TrimSpace(core.CABundleCerts) != "" || core.CABundleIncludeDoDCerts != nil || core.CABundleIncludePublicCerts != nil
 }
 
 type zarfPackageConfig struct {

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -668,7 +668,7 @@ services:
 	}
 }
 
-func TestWritePackageRendersCABundleAndUDSConfig(t *testing.T) {
+func TestWritePackageRendersCABundleConfigMap(t *testing.T) {
 	t.Parallel()
 
 	input := []byte(`name: trust-demo
@@ -681,9 +681,6 @@ x-uds:
         uds.dev/pod-reload: "true"
       annotations:
         uds.dev/pod-reload-selector: app=api
-    CA_BUNDLE_CERTS: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t
-    CA_BUNDLE_INCLUDE_DOD_CERTS: true
-    CA_BUNDLE_INCLUDE_PUBLIC_CERTS: "false"
 services:
   api:
     image: ghcr.io/acme/api:1.0.0
@@ -719,64 +716,48 @@ services:
 		t.Fatalf("expected caBundle annotation, got %#v", got)
 	}
 
-	udsConfig := readYAMLMap(t, filepath.Join(outDir, "uds-config.yaml"))
-	variables := mustMap(t, udsConfig["variables"])
-	core := mustMap(t, variables["core"])
-	if got := core["CA_BUNDLE_CERTS"]; got != "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t" {
-		t.Fatalf("expected CA_BUNDLE_CERTS, got %#v", got)
-	}
-	if got := core["CA_BUNDLE_INCLUDE_DOD_CERTS"]; got != "true" {
-		t.Fatalf("expected CA_BUNDLE_INCLUDE_DOD_CERTS to be normalized to string, got %#v", got)
-	}
-	if got := core["CA_BUNDLE_INCLUDE_PUBLIC_CERTS"]; got != "false" {
-		t.Fatalf("expected CA_BUNDLE_INCLUDE_PUBLIC_CERTS to be normalized to string, got %#v", got)
+	if _, err := os.Stat(filepath.Join(outDir, "uds-config.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("expected uds-config.yaml to be omitted, stat err = %v", err)
 	}
 }
 
-func TestWritePackageRendersUDSConfigWithoutPackageCABundle(t *testing.T) {
+func TestLoadCanonicalRejectsRemovedCABundleFields(t *testing.T) {
 	t.Parallel()
 
-	input := []byte(`name: trust-demo
-x-uds:
-  caBundle:
-    CA_BUNDLE_INCLUDE_PUBLIC_CERTS: true
-services:
-  api:
-    image: ghcr.io/acme/api:1.0.0
-    expose:
-      - "8080"
-`)
-
-	app, err := compose.LoadCanonicalYAML(input)
-	if err != nil {
-		t.Fatalf("LoadCanonicalYAML() error = %v", err)
-	}
-	outDir := t.TempDir()
-	if err := render.WritePackage(outDir, app); err != nil {
-		t.Fatalf("WritePackage() error = %v", err)
+	tests := []struct {
+		name    string
+		field   string
+		value   string
+		message string
+	}{
+		{name: "certs", field: "CA_BUNDLE_CERTS", value: `"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t"`, message: "invalid x-uds.caBundle.CA_BUNDLE_CERTS"},
+		{name: "dod", field: "CA_BUNDLE_INCLUDE_DOD_CERTS", value: "true", message: "invalid x-uds.caBundle.CA_BUNDLE_INCLUDE_DOD_CERTS"},
+		{name: "public", field: "CA_BUNDLE_INCLUDE_PUBLIC_CERTS", value: "true", message: "invalid x-uds.caBundle.CA_BUNDLE_INCLUDE_PUBLIC_CERTS"},
 	}
 
-	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
-	if strings.Contains(udsPackage, "caBundle:") {
-		t.Fatalf("did not expect package caBundle without configMap override\n%s", udsPackage)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := []byte("name: trust-demo\nx-uds:\n  caBundle:\n    " + tt.field + ": " + tt.value + "\nservices:\n  api:\n    image: ghcr.io/acme/api:1.0.0\n")
 
-	udsConfig := readYAMLMap(t, filepath.Join(outDir, "uds-config.yaml"))
-	variables := mustMap(t, udsConfig["variables"])
-	core := mustMap(t, variables["core"])
-	if got := core["CA_BUNDLE_INCLUDE_PUBLIC_CERTS"]; got != "true" {
-		t.Fatalf("expected CA_BUNDLE_INCLUDE_PUBLIC_CERTS to be rendered, got %#v", got)
+			_, err := compose.LoadCanonicalYAML(input)
+			if err == nil {
+				t.Fatalf("expected removed caBundle field %s to fail", tt.field)
+			}
+			if !strings.Contains(err.Error(), tt.message) {
+				t.Fatalf("expected removed caBundle field error, got %v", err)
+			}
+		})
 	}
 }
 
-func TestWritePackageOmitsUDSConfigWithoutCABundleVariables(t *testing.T) {
+func TestLoadCanonicalRejectsUnsupportedCABundleConfigMapField(t *testing.T) {
 	t.Parallel()
 
 	input := []byte(`name: trust-demo
 x-uds:
   caBundle:
     configMap:
-      name: custom-trust-bundle
+      target: custom-trust-bundle
 services:
   api:
     image: ghcr.io/acme/api:1.0.0
@@ -784,17 +765,12 @@ services:
       - "8080"
 `)
 
-	app, err := compose.LoadCanonicalYAML(input)
-	if err != nil {
-		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	_, err := compose.LoadCanonicalYAML(input)
+	if err == nil {
+		t.Fatalf("expected unsupported caBundle configMap field to fail")
 	}
-	outDir := t.TempDir()
-	if err := render.WritePackage(outDir, app); err != nil {
-		t.Fatalf("WritePackage() error = %v", err)
-	}
-
-	if _, err := os.Stat(filepath.Join(outDir, "uds-config.yaml")); !os.IsNotExist(err) {
-		t.Fatalf("expected uds-config.yaml to be omitted, stat err = %v", err)
+	if !strings.Contains(err.Error(), "invalid x-uds.caBundle.configMap.target") {
+		t.Fatalf("expected unsupported caBundle configMap field error, got %v", err)
 	}
 }
 
@@ -816,28 +792,6 @@ services:
 	}
 	if !strings.Contains(err.Error(), "invalid x-uds.caBundle.configMap") {
 		t.Fatalf("expected caBundle configMap validation error, got %v", err)
-	}
-}
-
-func TestLoadCanonicalRejectsInvalidCABundleBoolType(t *testing.T) {
-	t.Parallel()
-
-	input := []byte(`name: trust-demo
-x-uds:
-  caBundle:
-    CA_BUNDLE_INCLUDE_DOD_CERTS:
-      nope: true
-services:
-  api:
-    image: ghcr.io/acme/api:1.0.0
-`)
-
-	_, err := compose.LoadCanonicalYAML(input)
-	if err == nil {
-		t.Fatalf("expected invalid caBundle bool type to fail")
-	}
-	if !strings.Contains(err.Error(), "invalid x-uds.caBundle.CA_BUNDLE_INCLUDE_DOD_CERTS") {
-		t.Fatalf("expected caBundle boolean validation error, got %v", err)
 	}
 }
 

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -8,6 +8,7 @@ import (
 
 	"defenseunicorns/uds-compose-bridge/internal/compose"
 	"defenseunicorns/uds-compose-bridge/internal/render"
+	yamlv3 "gopkg.in/yaml.v3"
 )
 
 func TestLoadCanonicalAcceptsExplicitLocalBuildImage(t *testing.T) {
@@ -667,6 +668,179 @@ services:
 	}
 }
 
+func TestWritePackageRendersCABundleAndUDSConfig(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: trust-demo
+x-uds:
+  caBundle:
+    configMap:
+      name: custom-trust-bundle
+      key: roots.pem
+      labels:
+        uds.dev/pod-reload: "true"
+      annotations:
+        uds.dev/pod-reload-selector: app=api
+    CA_BUNDLE_CERTS: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t
+    CA_BUNDLE_INCLUDE_DOD_CERTS: true
+    CA_BUNDLE_INCLUDE_PUBLIC_CERTS: "false"
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    expose:
+      - "8080"
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	udsPackage := readYAMLMap(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	spec := mustMap(t, udsPackage["spec"])
+	caBundle := mustMap(t, spec["caBundle"])
+	configMap := mustMap(t, caBundle["configMap"])
+	if got := configMap["name"]; got != "custom-trust-bundle" {
+		t.Fatalf("expected caBundle configMap name, got %#v", got)
+	}
+	if got := configMap["key"]; got != "roots.pem" {
+		t.Fatalf("expected caBundle configMap key, got %#v", got)
+	}
+	labels := mustMap(t, configMap["labels"])
+	if got := labels["uds.dev/pod-reload"]; got != "true" {
+		t.Fatalf("expected caBundle label, got %#v", got)
+	}
+	annotations := mustMap(t, configMap["annotations"])
+	if got := annotations["uds.dev/pod-reload-selector"]; got != "app=api" {
+		t.Fatalf("expected caBundle annotation, got %#v", got)
+	}
+
+	udsConfig := readYAMLMap(t, filepath.Join(outDir, "uds-config.yaml"))
+	variables := mustMap(t, udsConfig["variables"])
+	core := mustMap(t, variables["core"])
+	if got := core["CA_BUNDLE_CERTS"]; got != "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t" {
+		t.Fatalf("expected CA_BUNDLE_CERTS, got %#v", got)
+	}
+	if got := core["CA_BUNDLE_INCLUDE_DOD_CERTS"]; got != "true" {
+		t.Fatalf("expected CA_BUNDLE_INCLUDE_DOD_CERTS to be normalized to string, got %#v", got)
+	}
+	if got := core["CA_BUNDLE_INCLUDE_PUBLIC_CERTS"]; got != "false" {
+		t.Fatalf("expected CA_BUNDLE_INCLUDE_PUBLIC_CERTS to be normalized to string, got %#v", got)
+	}
+}
+
+func TestWritePackageRendersUDSConfigWithoutPackageCABundle(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: trust-demo
+x-uds:
+  caBundle:
+    CA_BUNDLE_INCLUDE_PUBLIC_CERTS: true
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    expose:
+      - "8080"
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	if strings.Contains(udsPackage, "caBundle:") {
+		t.Fatalf("did not expect package caBundle without configMap override\n%s", udsPackage)
+	}
+
+	udsConfig := readYAMLMap(t, filepath.Join(outDir, "uds-config.yaml"))
+	variables := mustMap(t, udsConfig["variables"])
+	core := mustMap(t, variables["core"])
+	if got := core["CA_BUNDLE_INCLUDE_PUBLIC_CERTS"]; got != "true" {
+		t.Fatalf("expected CA_BUNDLE_INCLUDE_PUBLIC_CERTS to be rendered, got %#v", got)
+	}
+}
+
+func TestWritePackageOmitsUDSConfigWithoutCABundleVariables(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: trust-demo
+x-uds:
+  caBundle:
+    configMap:
+      name: custom-trust-bundle
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    expose:
+      - "8080"
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(outDir, "uds-config.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("expected uds-config.yaml to be omitted, stat err = %v", err)
+	}
+}
+
+func TestLoadCanonicalRejectsInvalidCABundleConfigMapType(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: trust-demo
+x-uds:
+  caBundle:
+    configMap: nope
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+`)
+
+	_, err := compose.LoadCanonicalYAML(input)
+	if err == nil {
+		t.Fatalf("expected invalid caBundle configMap type to fail")
+	}
+	if !strings.Contains(err.Error(), "invalid x-uds.caBundle.configMap") {
+		t.Fatalf("expected caBundle configMap validation error, got %v", err)
+	}
+}
+
+func TestLoadCanonicalRejectsInvalidCABundleBoolType(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: trust-demo
+x-uds:
+  caBundle:
+    CA_BUNDLE_INCLUDE_DOD_CERTS:
+      nope: true
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+`)
+
+	_, err := compose.LoadCanonicalYAML(input)
+	if err == nil {
+		t.Fatalf("expected invalid caBundle bool type to fail")
+	}
+	if !strings.Contains(err.Error(), "invalid x-uds.caBundle.CA_BUNDLE_INCLUDE_DOD_CERTS") {
+		t.Fatalf("expected caBundle boolean validation error, got %v", err)
+	}
+}
+
 func readFile(t *testing.T, path string) string {
 	t.Helper()
 	data, err := os.ReadFile(path)
@@ -674,4 +848,23 @@ func readFile(t *testing.T, path string) string {
 		t.Fatalf("read file %s: %v", path, err)
 	}
 	return string(data)
+}
+
+func readYAMLMap(t *testing.T, path string) map[string]any {
+	t.Helper()
+	content := readFile(t, path)
+	var out map[string]any
+	if err := yamlv3.Unmarshal([]byte(content), &out); err != nil {
+		t.Fatalf("unmarshal yaml %s: %v", path, err)
+	}
+	return out
+}
+
+func mustMap(t *testing.T, value any) map[string]any {
+	t.Helper()
+	m, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", value)
+	}
+	return m
 }


### PR DESCRIPTION
# Summary
- Add x-uds.caBundle support to the Compose bridge.
- Render x-uds.caBundle.configMap into spec.caBundle in manifests/uds-package.yaml.
- Generate out/uds-config.yaml when any of the bridge-only trust bundle inputs are present:
  - CA_BUNDLE_CERTS
  - CA_BUNDLE_INCLUDE_DOD_CERTS
  - CA_BUNDLE_INCLUDE_PUBLIC_CERTS
- Validate caBundle input types and normalize boolean trust bundle flags to string values in uds-config.yaml.
- Update the README and example Compose file to document the new grouped input and split outputs.
- Add test coverage for combined, partial, omission, and invalid-input cases.
# Why
This completes support for the upstream UDS Package caBundle spec while keeping the user experience in compose.yaml simple.
The bridge now lets users define both parts of trust bundle configuration in one place:
- Package-scoped trust bundle distribution settings via x-uds.caBundle.configMap
- UDS Core trust bundle source variables via x-uds.caBundle.CA_BUNDLE_*
Those inputs are then split into the correct outputs for UDS:
- spec.caBundle in the generated Package CR
- variables.core.* in a generated uds-config.yaml
# Notes
- The bridge does not generate the trust bundle ConfigMap itself.
- UDS Core remains responsible for creating and populating the operator-managed trust bundle ConfigMap in the package namespace.
- CA_BUNDLE_CERTS is expected to be supplied as a base64-encoded PEM bundle, matching the UDS Core documentation.