### PR TITLE
chore: add simple example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,19 @@ A [Docker Compose Bridge](https://docs.docker.com/compose/bridge/) transformatio
 
 ## Quickstart
 
-The following example deploys UDS Core Slim Dev on k3d, and packages an example `compose.yaml`:
+The following example deploys UDS Core Slim Dev on k3d, and also packages and deploys Wordpress and MySQL:
 
 ```sh
 # (optionally) deploy UDS Core Slim Dev
 uds deploy k3d-core-slim-dev
 
-# build the example
-cd examples/full
-docker compose build
-
-# run the transformation
+# perform the tranformation
+cd examples/simple
 docker compose bridge convert -t ghcr.io/defenseunicorns-dashdays/compose-bridge-uds
 
 # build and deploy the package
 zarf package create out/
-zarf package deploy zarf-package-hello-world-*.tar.zst
+zarf package deploy zarf-package-wordpress-*.tar.zst
 ```
 
 ## Compose structure

--- a/examples/simple/compose.yaml
+++ b/examples/simple/compose.yaml
@@ -1,0 +1,45 @@
+name: wordpress
+
+services:
+  wordpress:
+    image: wordpress:latest
+    ports:
+      - "8000:80"
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_DB_PASSWORD_FILE: /run/secrets/db_password
+    secrets:
+      - db_password
+    volumes:
+      - wordpress_data:/var/www/html
+    depends_on:
+      - db
+
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD_FILE: /run/secrets/db_password
+      MYSQL_RANDOM_ROOT_PASSWORD: "1"
+    secrets:
+      - db_password
+    expose:
+      - "3306"
+    volumes:
+      - db_data:/var/lib/mysql
+
+secrets:
+  db_password:
+    file: ./db_password.txt
+
+volumes:
+  wordpress_data: {}
+  db_data: {}
+
+x-uds:
+  network:
+    expose:
+      - service: wordpress

--- a/examples/simple/db_password.txt
+++ b/examples/simple/db_password.txt
@@ -1,0 +1,1 @@
+changeme


### PR DESCRIPTION
adds a simple compose example that doesn't build images on the fly, but instead pulls them from dockerhub