### PR TITLE
feat: rewrite auto-expose port logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The bridge maps the [Compose Specification](https://compose-spec.io/) to Kuberne
 | `depends_on:` | Converted to init-container wait logic using `netcat` (busybox). The dependency must declare a port. |
 | `healthcheck:` | `CMD` and `CMD-SHELL` forms convert to Kubernetes liveness probes. |
 | `deploy.resources` | `limits` and `reservations` map to Pod resource requests/limits. |
-| `ports:` | Services with published ports are auto-exposed via the UDS tenant gateway. `expose:` (internal-only) ports are not exposed externally. |
+| `ports:` | Published ports are auto-exposed via the UDS tenant gateway. `expose:` (internal-only) ports are not exposed externally. Compose port declaration order is preserved, and long-syntax `name` / `app_protocol` hints are used to prefer web ports for multi-port services. |
 
 ## Unsupported Compose configuration
 
@@ -76,7 +76,7 @@ Most of the UDS Package CR is inferred from your Compose model. Reach for `x-uds
 
 ### Auto-generated
 
-- **Expose** — services with published `ports:` are exposed on the tenant gateway (`host` = service name, `gateway` = `tenant`, `selector`/`podLabels` = `app.kubernetes.io/name: <service>`).
+- **Expose** — services with published `ports:` are exposed on the tenant gateway (`host` = service name, `gateway` = `tenant`, `selector`/`podLabels` = `app.kubernetes.io/name: <service>`). For multi-port services, the bridge prefers ports whose Compose `app_protocol` or `name` indicates web traffic (`http`, `https`, `http2`, `h2c`, `grpc`, `grpcs`, `web`, `www`), then falls back to the first declared published port. Ports are not filtered by port number or transport protocol.
 - **Network allow** — intra-namespace ingress/egress rules are always included so services in the namespace can communicate.
 - **SSO** — a Keycloak client is generated for the first exposed service (`clientId` = project name, `redirectUris` = `https://<host>.uds.dev/*`). Omitted when no services are exposed.
 
@@ -111,6 +111,7 @@ See [`examples/full/compose.yaml`](examples/full/compose.yaml) for a complete wo
 
 ### Notes on specific keys
 
+- **Auto-expose port selection** — For services with multiple published ports, prefer Compose long syntax with `name` and/or `app_protocol` to identify the web-facing port, or use `x-uds.network.expose[].port` to pin the intended port if inference is ambiguous. The bridge does not automatically skip SSH, DNS, UDP, or other non-HTTP-looking ports.
 - **`x-uds.sso`** — If omitted, the bridge infers an SSO client for the first exposed service. If explicitly set to an empty list (`x-uds.sso: []`), inferred SSO is disabled.
 - **`x-uds.monitor[]`** — Each entry may be a raw UDS `spec.monitor[]` item, or may use the bridge-only `service` key to infer labels and port metadata. For multi-port services, set either `portName` or `targetPort` so the bridge picks the intended metrics port.
 - **`x-uds.caBundle.configMap`** — Customizes the namespace trust-bundle ConfigMap created by UDS Core. The actual trust bundle contents are configured separately in UDS Core and are not part of the Package CR.

--- a/examples/full/compose.yaml
+++ b/examples/full/compose.yaml
@@ -10,7 +10,11 @@ services:
     environment:
       APP_MESSAGE: "Hello from compose!"
     ports:
-      - "8080:8080"
+      - name: http
+        target: 8080
+        published: "8080"
+        protocol: tcp
+        app_protocol: http
     volumes:
       - hello-data:/var/lib/hello
     configs:

--- a/examples/simple/compose.yaml
+++ b/examples/simple/compose.yaml
@@ -4,11 +4,7 @@ services:
   wordpress:
     image: wordpress:latest
     ports:
-      - name: http
-        target: 80
-        published: "8000"
-        protocol: tcp
-        app_protocol: http
+      - "8000:80"
     environment:
       WORDPRESS_DB_HOST: db
       WORDPRESS_DB_USER: wordpress

--- a/examples/simple/compose.yaml
+++ b/examples/simple/compose.yaml
@@ -4,7 +4,11 @@ services:
   wordpress:
     image: wordpress:latest
     ports:
-      - "8000:80"
+      - name: http
+        target: 80
+        published: "8000"
+        protocol: tcp
+        app_protocol: http
     environment:
       WORDPRESS_DB_HOST: db
       WORDPRESS_DB_USER: wordpress

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -426,12 +426,19 @@ func parsePorts(rawPorts []types.ServicePortConfig, expose types.StringOrNumberL
 			continue
 		}
 		proto := protocolOrDefault(raw.Protocol)
-		key := fmt.Sprintf("%d/%s", raw.Target, proto)
+		key := portKey(int(raw.Target), proto)
 		if _, exists := seen[key]; exists {
 			continue
 		}
 		seen[key] = struct{}{}
-		ports = append(ports, model.Port{Number: int(raw.Target), Protocol: proto, Raw: key, Published: true})
+		ports = append(ports, model.Port{
+			Number:      int(raw.Target),
+			Protocol:    proto,
+			Raw:         key,
+			Published:   true,
+			Name:        strings.TrimSpace(raw.Name),
+			AppProtocol: strings.TrimSpace(raw.AppProtocol),
+		})
 	}
 
 	for _, token := range expose {
@@ -439,7 +446,7 @@ func parsePorts(rawPorts []types.ServicePortConfig, expose types.StringOrNumberL
 		if err != nil {
 			return nil, err
 		}
-		key := fmt.Sprintf("%d/%s", target, proto)
+		key := portKey(target, proto)
 		if _, exists := seen[key]; exists {
 			continue
 		}
@@ -447,13 +454,11 @@ func parsePorts(rawPorts []types.ServicePortConfig, expose types.StringOrNumberL
 		ports = append(ports, model.Port{Number: target, Protocol: proto, Raw: key})
 	}
 
-	sort.Slice(ports, func(i, j int) bool {
-		if ports[i].Number == ports[j].Number {
-			return ports[i].Protocol < ports[j].Protocol
-		}
-		return ports[i].Number < ports[j].Number
-	})
 	return ports, nil
+}
+
+func portKey(number int, proto string) string {
+	return fmt.Sprintf("%d/%s", number, protocolOrDefault(proto))
 }
 
 func parsePortToken(token string) (int, string, error) {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -1,6 +1,9 @@
 package model
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const (
 	DefaultVersion      = "0.1.0"
@@ -8,10 +11,31 @@ const (
 )
 
 type Port struct {
-	Number    int
-	Protocol  string
-	Raw       string
-	Published bool
+	Number      int
+	Protocol    string
+	Raw         string
+	Published   bool
+	Name        string
+	AppProtocol string
+}
+
+func (p Port) HasWebHint() bool {
+	return IsWebPortHint(p.AppProtocol) || IsWebPortHint(p.Name)
+}
+
+func IsWebPortHint(value string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	if idx := strings.LastIndex(normalized, "/"); idx >= 0 {
+		normalized = normalized[idx+1:]
+	}
+	normalized = strings.ReplaceAll(normalized, "_", "-")
+
+	switch normalized {
+	case "http", "https", "http2", "h2c", "grpc", "grpcs", "web", "www":
+		return true
+	default:
+		return false
+	}
 }
 
 type EnvVar struct {

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -386,7 +386,7 @@ func setDefault(m map[string]any, key string, value any) {
 	}
 }
 
-// buildAutoExposes generates expose entries for all services with published ports.
+// buildAutoExposes generates tenant-gateway expose entries for services with published ports.
 func buildAutoExposes(app model.App) []any {
 	var expose []any
 	for _, svc := range app.Services {
@@ -428,7 +428,9 @@ func enrichNetworkExposes(app model.App) []any {
 			setDefault(item, "selector", svcSelector)
 			setDefault(item, "podLabels", svcSelector)
 			if _, exists := item["port"]; !exists {
-				if port, err := svc.PrimaryPort(); err == nil {
+				if port, ok := primaryGatewayPort(svc.Ports, false); ok {
+					item["port"] = port.Number
+				} else if port, err := svc.PrimaryPort(); err == nil {
 					item["port"] = port.Number
 				}
 			}
@@ -733,12 +735,25 @@ func titleCase(name string) string {
 }
 
 func primaryPublishedPort(ports []model.Port) (model.Port, bool) {
+	return primaryGatewayPort(ports, true)
+}
+
+func primaryGatewayPort(ports []model.Port, requirePublished bool) (model.Port, bool) {
 	for _, port := range ports {
-		if port.Published {
+		if gatewayPortCandidate(port, requirePublished) && port.HasWebHint() {
+			return port, true
+		}
+	}
+	for _, port := range ports {
+		if gatewayPortCandidate(port, requirePublished) {
 			return port, true
 		}
 	}
 	return model.Port{}, false
+}
+
+func gatewayPortCandidate(port model.Port, requirePublished bool) bool {
+	return !requirePublished || port.Published
 }
 
 func buildVolumes(svc model.Service) ([]volumeSpec, []volumeMountSpec) {
@@ -864,10 +879,11 @@ func buildServicePorts(ports []model.Port) []servicePort {
 	out := make([]servicePort, 0, len(ports))
 	for i, port := range ports {
 		out = append(out, servicePort{
-			Name:       buildPortName(i, port),
-			Port:       port.Number,
-			Protocol:   strings.ToUpper(port.Protocol),
-			TargetPort: port.Number,
+			Name:        buildPortName(i, port),
+			Port:        port.Number,
+			Protocol:    strings.ToUpper(port.Protocol),
+			TargetPort:  port.Number,
+			AppProtocol: port.AppProtocol,
 		})
 	}
 	return out
@@ -965,10 +981,24 @@ func buildSecretVariableName(secretName string, used map[string]struct{}) string
 }
 
 func buildPortName(index int, port model.Port) string {
+	if name := sanitizePortName(port.Name); name != "" {
+		return name
+	}
 	if index == 0 && strings.EqualFold(port.Protocol, "TCP") {
 		return "http"
 	}
 	return fmt.Sprintf("port-%d-%s", port.Number, strings.ToLower(port.Protocol))
+}
+
+func sanitizePortName(raw string) string {
+	name := strings.ToLower(strings.TrimSpace(raw))
+	name = strings.ReplaceAll(name, "_", "-")
+	name = invalidPortNameRunes.ReplaceAllString(name, "-")
+	name = strings.Trim(name, "-")
+	if len(name) > 63 {
+		name = strings.TrimRight(name[:63], "-")
+	}
+	return name
 }
 
 func resolveSecretTargetPath(source string, target string) string {
@@ -1135,6 +1165,7 @@ func dedupeStrings(values []string) []string {
 }
 
 var invalidManifestNameRunes = regexp.MustCompile(`[^a-z0-9.-]+`)
+var invalidPortNameRunes = regexp.MustCompile(`[^a-z0-9-]+`)
 var invalidSecretVariableRunes = regexp.MustCompile(`[^A-Z0-9_]+`)
 
 func sanitizeManifestName(raw string) string {
@@ -1317,10 +1348,11 @@ type serviceSpec struct {
 }
 
 type servicePort struct {
-	Name       string `yaml:"name,omitempty"`
-	Port       int    `yaml:"port"`
-	TargetPort int    `yaml:"targetPort,omitempty"`
-	Protocol   string `yaml:"protocol,omitempty"`
+	Name        string `yaml:"name,omitempty"`
+	Port        int    `yaml:"port"`
+	TargetPort  int    `yaml:"targetPort,omitempty"`
+	Protocol    string `yaml:"protocol,omitempty"`
+	AppProtocol string `yaml:"appProtocol,omitempty"`
 }
 
 type udsPackageManifest struct {

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -994,9 +994,13 @@ func sanitizePortName(raw string) string {
 	name := strings.ToLower(strings.TrimSpace(raw))
 	name = strings.ReplaceAll(name, "_", "-")
 	name = invalidPortNameRunes.ReplaceAllString(name, "-")
+	name = repeatedPortNameHyphens.ReplaceAllString(name, "-")
 	name = strings.Trim(name, "-")
-	if len(name) > 63 {
-		name = strings.TrimRight(name[:63], "-")
+	if len(name) > 15 {
+		name = strings.Trim(name[:15], "-")
+	}
+	if !portNameLetter.MatchString(name) {
+		return ""
 	}
 	return name
 }
@@ -1166,6 +1170,8 @@ func dedupeStrings(values []string) []string {
 
 var invalidManifestNameRunes = regexp.MustCompile(`[^a-z0-9.-]+`)
 var invalidPortNameRunes = regexp.MustCompile(`[^a-z0-9-]+`)
+var repeatedPortNameHyphens = regexp.MustCompile(`-+`)
+var portNameLetter = regexp.MustCompile(`[a-z]`)
 var invalidSecretVariableRunes = regexp.MustCompile(`[^A-Z0-9_]+`)
 
 func sanitizeManifestName(raw string) string {

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -217,6 +217,163 @@ services:
 	}
 }
 
+func TestWritePackageAutoExposeUsesComposePortDeclarationOrder(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: homelab
+services:
+  gitea:
+    image: docker.gitea.com/gitea:1.25.5
+    ports:
+      - "3000:3000"
+      - "222:22"
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	expose := firstExposeRule(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	if got := expose["port"]; got != 3000 {
+		t.Fatalf("expected first declared published port 3000 to be auto-exposed, got %#v", got)
+	}
+}
+
+func TestWritePackageAutoExposePrefersWebAppProtocolHint(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: homelab
+services:
+  gitea:
+    image: docker.gitea.com/gitea:1.25.5
+    ports:
+      - name: ssh
+        target: 22
+        published: "222"
+        protocol: tcp
+        app_protocol: ssh
+      - name: web
+        target: 3000
+        published: "3000"
+        protocol: tcp
+        app_protocol: http
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	expose := firstExposeRule(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	if got := expose["port"]; got != 3000 {
+		t.Fatalf("expected app_protocol http port 3000 to be auto-exposed instead of SSH, got %#v", got)
+	}
+
+	service := readFile(t, filepath.Join(outDir, "manifests", "service-gitea.yaml"))
+	if !strings.Contains(service, "appProtocol: http") {
+		t.Fatalf("expected Service port to preserve app_protocol hint\n%s", service)
+	}
+}
+
+func TestWritePackageAutoExposePrefersWebPortNameHint(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: homelab
+services:
+  gitea:
+    image: docker.gitea.com/gitea:1.25.5
+    ports:
+      - name: ssh
+        target: 22
+        published: "222"
+        protocol: tcp
+      - name: web
+        target: 3000
+        published: "3000"
+        protocol: tcp
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	expose := firstExposeRule(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	if got := expose["port"]; got != 3000 {
+		t.Fatalf("expected web-named port 3000 to be auto-exposed instead of SSH, got %#v", got)
+	}
+}
+
+func TestWritePackageAutoExposeAllowsNonHTTPPortsWithoutFiltering(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: ssh-only
+services:
+  bastion:
+    image: ghcr.io/acme/bastion:1.0.0
+    ports:
+      - "222:22"
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	expose := firstExposeRule(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	if got := expose["port"]; got != 22 {
+		t.Fatalf("expected first declared published port 22 to remain eligible for auto-expose, got %#v", got)
+	}
+}
+
+func TestWritePackageAutoExposeAllowsUDPPublishedPortsWithoutFiltering(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: dns-demo
+services:
+  dns:
+    image: ghcr.io/acme/dns:1.0.0
+    ports:
+      - "1053:53/udp"
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	expose := firstExposeRule(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	if got := expose["port"]; got != 53 {
+		t.Fatalf("expected UDP port 53 to remain eligible for auto-expose, got %#v", got)
+	}
+
+	service := readFile(t, filepath.Join(outDir, "manifests", "service-dns.yaml"))
+	if !strings.Contains(service, "protocol: UDP") {
+		t.Fatalf("expected Service port to preserve UDP protocol\n%s", service)
+	}
+}
+
 func TestExposeEnrichmentFillsDefaults(t *testing.T) {
 	t.Parallel()
 
@@ -793,6 +950,18 @@ services:
 	if !strings.Contains(err.Error(), "invalid x-uds.caBundle.configMap") {
 		t.Fatalf("expected caBundle configMap validation error, got %v", err)
 	}
+}
+
+func firstExposeRule(t *testing.T, path string) map[string]any {
+	t.Helper()
+	udsPackage := readYAMLMap(t, path)
+	spec := mustMap(t, udsPackage["spec"])
+	network := mustMap(t, spec["network"])
+	exposes, ok := network["expose"].([]any)
+	if !ok || len(exposes) == 0 {
+		t.Fatalf("expected at least one expose rule in %s, got %#v", path, network["expose"])
+	}
+	return mustMap(t, exposes[0])
 }
 
 func readFile(t *testing.T, path string) string {

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -374,6 +374,44 @@ services:
 	}
 }
 
+func TestWritePackageSanitizesComposePortNames(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: port-name-demo
+services:
+  web:
+    image: ghcr.io/acme/web:1.0.0
+    ports:
+      - name: WEB__UI
+        target: 8080
+        published: "8080"
+        protocol: tcp
+      - name: "123"
+        target: 9090
+        published: "9090"
+        protocol: tcp
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	service := readFile(t, filepath.Join(outDir, "manifests", "service-web.yaml"))
+	for _, want := range []string{
+		"name: web-ui",
+		"name: port-9090-tcp",
+	} {
+		if !strings.Contains(service, want) {
+			t.Fatalf("expected service port name %q\n%s", want, service)
+		}
+	}
+}
+
 func TestExposeEnrichmentFillsDefaults(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This is a purposed solution to issue #14 

The declared ports are no longer sorted numerically and lowest port chosen to be exposed. Instead, `ports:` declaration order in `compose.yaml` is now preserved and first declared port is auto-exposed in the absence of additional context.

Compose long syntax (https://github.com/compose-spec/compose-spec/blob/main/05-services.md#long-syntax-3) is now preferred in the `compose.yaml` as this explicitly defines what port(s) should be exposed. 

Example from issue #14 using long syntax:
```yaml
services:
  gitea:
    image: docker.gitea.com/gitea:1.25.5
    ports:
      - name: http
        target: 3000
        published: "3000"
        protocol: tcp
        app_protocol: http
      - name: ssh
        target: 22
        published: "222"
        protocol: tcp
```

Users can still pin exposed ports through `x-uds.network.expose`:
```yaml
x-uds:                                                                           
 network:                                                                       
   expose:                                                                      
     - service: gitea                                                           
       port: 3000
```