### PR TITLE
feat: skip bind mounts with warning instead of hard error

### DIFF
--- a/examples/simple/compose.yaml
+++ b/examples/simple/compose.yaml
@@ -14,6 +14,7 @@ services:
       - db_password
     volumes:
       - wordpress_data:/var/www/html
+      - ./themes:/var/www/html/wp-content/themes  # bind mount: skipped during k8s conversion
     depends_on:
       - db
 

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -509,7 +509,8 @@ func parseServiceVolumes(raw []types.ServiceVolumeConfig, serviceName string, al
 
 		switch mountType {
 		case "bind":
-			return nil, fmt.Errorf("service %q uses bind mount %q:%q; bind mounts are not supported, use compose configs/secrets or named volumes instead", serviceName, source, target)
+			fmt.Fprintf(os.Stderr, "warning: service %q bind mount %q:%q skipped; bind mounts have no equivalent in Kubernetes\n", serviceName, source, target)
+			continue
 		case "volume":
 			name := strings.TrimSpace(source)
 			if name == "" {

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -8,6 +8,7 @@ import (
 
 	"defenseunicorns/uds-compose-bridge/internal/compose"
 	"defenseunicorns/uds-compose-bridge/internal/render"
+
 	yamlv3 "gopkg.in/yaml.v3"
 )
 
@@ -38,7 +39,7 @@ services:
 	}
 }
 
-func TestLoadCanonicalRejectsBindMounts(t *testing.T) {
+func TestLoadCanonicalSkipsBindMounts(t *testing.T) {
 	t.Parallel()
 
 	input := []byte(`name: demo
@@ -49,16 +50,20 @@ services:
       - ./data:/app/data
 `)
 
-	_, err := compose.LoadCanonicalYAML(input)
-	if err == nil {
-		t.Fatalf("expected bind mount to fail")
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("expected bind mount to be skipped, got error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "bind mount") {
-		t.Fatalf("expected bind mount error, got %v", err)
+	for _, svc := range app.Services {
+		for _, vm := range svc.Volumes {
+			if vm.Target == "/app/data" {
+				t.Fatalf("bind mount should have been skipped, but found volume mount for /app/data")
+			}
+		}
 	}
 }
 
-func TestLoadCanonicalFileRejectsBindMountsAfterEnvFileNormalization(t *testing.T) {
+func TestLoadCanonicalFileSkipsBindMountsAfterEnvFileNormalization(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -80,11 +85,8 @@ services:
 	}
 
 	_, err := compose.LoadCanonicalFile(composePath)
-	if err == nil {
-		t.Fatalf("expected bind mount fixture to fail")
-	}
-	if !strings.Contains(err.Error(), "bind mount") {
-		t.Fatalf("expected bind mount error after env_file normalization, got %v", err)
+	if err != nil {
+		t.Fatalf("expected bind mount to be skipped after env_file normalization, got error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Bind mounts now emit a stderr warning and are omitted from the converted manifests rather than failing the entire conversion. Updates tests and adds bind mount example to simple compose fixture.