### PR TITLE
feat!: create Helm chart instead of raw manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # compose-bridge-uds
 
-Convert a Docker Compose application into a deployable [UDS](https://uds.defenseunicorns.com/) package using [Docker Compose Bridge](https://docs.docker.com/compose/bridge/). The transformation consumes a fully-resolved Compose model and emits a Zarf package definition — Kubernetes manifests plus a UDS Package CR — ready for `zarf package create` and `zarf package deploy`.
+Convert a Docker Compose application into a deployable [UDS](https://uds.defenseunicorns.com/) package using [Docker Compose Bridge](https://docs.docker.com/compose/bridge/). The transformation consumes a fully-resolved Compose model and emits a Helm chart — the Kubernetes resources plus a UDS Package CR — referenced by a Zarf package definition, ready for `zarf package create` and `zarf package deploy`. Rendering Kubernetes resources through a Helm chart conforms to the UDS Package requirement to use Helm charts for rendering.
 
 > [!IMPORTANT]
 > **This is not a supported product pathway.** It's an experimental transformation we're sharing to gather signal. If you find it useful — or hit rough edges — please open an issue. Your feedback is what tells us whether to invest further.
@@ -34,7 +34,7 @@ This walkthrough deploys UDS Core Slim Dev on k3d, then packages and deploys Wor
 uds deploy k3d-core-slim-dev:latest
 ```
 
-**2. Run the bridge transformation.** This writes Kubernetes manifests and a Zarf package definition to `out/`:
+**2. Run the bridge transformation.** This writes a Helm chart to `out/chart/` and a Zarf package definition to `out/zarf.yaml` (plus `out/values/` when the Compose file declares secrets):
 
 ```sh
 cd examples/simple
@@ -58,11 +58,13 @@ docker compose build
 docker compose bridge convert -t ghcr.io/defenseunicorns-labs/compose-bridge-uds
 ```
 
-When `image:` is omitted, Compose assigns a default image name based on the project and service, such as `hello-world-server` for `examples/full`. To make the generated Kubernetes manifests and `zarf.yaml` use a stable or registry-backed reference, declare `image:` on the service before running `docker compose build`.
+When `image:` is omitted, Compose assigns a default image name based on the project and service, such as `hello-world-server` for `examples/full`. To make the generated Helm chart and `zarf.yaml` use a stable or registry-backed reference, declare `image:` on the service before running `docker compose build`.
 
 ## How it works
 
-The bridge maps the [Compose Specification](https://compose-spec.io/) to Kubernetes resources (Deployments, Services, PVCs, ConfigMaps, Secrets) and synthesizes a [UDS Package CR](https://docs.defenseunicorns.com/core/reference/operator--crds/packages-v1alpha1-cr/) for network policy, monitoring, SSO, and trust-bundle distribution. You can guide that synthesis with `x-uds` [extension keys](https://docs.docker.com/reference/compose-file/extension/) at the top level of your `compose.yaml`.
+The bridge maps the [Compose Specification](https://compose-spec.io/) to Kubernetes resources (Deployments, Services, PVCs, ConfigMaps, Secrets) and synthesizes a [UDS Package CR](https://docs.defenseunicorns.com/core/reference/operator--crds/packages-v1alpha1-cr/) for network policy, monitoring, SSO, and trust-bundle distribution. All of these are rendered as templates of a single generated Helm chart under `out/chart/`, which the `out/zarf.yaml` package deploys via a `charts:` reference (`localPath: chart`). You can guide that synthesis with `x-uds` [extension keys](https://docs.docker.com/reference/compose-file/extension/) at the top level of your `compose.yaml`.
+
+Secrets are rendered from chart values rather than baked into the template, so Zarf's variable substitution still applies: the bridge writes a Zarf-templated `out/values/values.yaml` (referenced by the component's `charts[].valuesFiles`) carrying `###ZARF_VAR_*###` placeholders, and each `Secret` template reads its value from `.Values.secrets.*`. The `zarf.yaml` `variables:` (prompt + sensitive) are unchanged.
 
 ## Supported Compose configuration
 
@@ -78,8 +80,8 @@ The bridge maps the [Compose Specification](https://compose-spec.io/) to Kuberne
 | `healthcheck:` | `CMD` and `CMD-SHELL` forms convert to Kubernetes liveness probes. |
 | `deploy.resources` | `limits` and `reservations` map to Pod resource requests/limits. |
 | `ports:` | Published ports are auto-exposed via the UDS tenant gateway. `expose:` (internal-only) ports are not exposed externally. Compose port declaration order is preserved, and long-syntax `name` / `app_protocol` hints are used to prefer web ports for multi-port services. |
-| Bind mounts | Skipped during conversion with a warning because host paths do not have a portable Kubernetes equivalent. Use named `volumes:`, `configs:`, or `secrets:` for data that should be rendered into manifests. |
-| `user:`, `privileged:`, `cap_add:`, `cap_drop:`, `security_opt:` | Reflected in the container security context where applicable. Settings that require UDS policy exceptions also generate a `manifests/uds-exemption.yaml`. |
+| Bind mounts | Skipped during conversion with a warning because host paths do not have a portable Kubernetes equivalent. Use named `volumes:`, `configs:`, or `secrets:` for data that should be rendered into the chart. |
+| `user:`, `privileged:`, `cap_add:`, `cap_drop:`, `security_opt:` | Reflected in the container security context where applicable. Settings that require UDS policy exceptions also generate a `chart/templates/uds-exemption.yaml`. |
 
 ## Unsupported Compose configuration
 
@@ -94,7 +96,7 @@ Most of the UDS Package CR is inferred from your Compose model. Reach for `x-uds
 - **Expose** — services with published `ports:` are exposed on the tenant gateway (`host` = service name, `gateway` = `tenant`, `selector`/`podLabels` = `app.kubernetes.io/name: <service>`). For multi-port services, the bridge prefers ports whose Compose `app_protocol` or `name` indicates web traffic (`http`, `https`, `http2`, `h2c`, `grpc`, `grpcs`, `web`, `www`), then falls back to the first declared published port. Ports are not filtered by port number or transport protocol.
 - **Network allow** — intra-namespace ingress/egress rules are always included so services in the namespace can communicate.
 - **SSO** — a Keycloak client is generated for the first exposed service (`clientId` = project name, `redirectUris` = `https://<host>.uds.dev/*`). Omitted when no services are exposed.
-- **Policy exemptions** — services that require UDS policy exceptions generate a `manifests/uds-exemption.yaml`, which is included in `zarf.yaml` with the rest of the rendered manifests.
+- **Policy exemptions** — services that require UDS policy exceptions are rendered as `chart/templates/uds-exemption.yaml` (namespace `uds-policy-exemptions`) in the generated chart, deployed with the rest of the package.
 
 ### Opt-in
 
@@ -111,7 +113,7 @@ Most of the UDS Package CR is inferred from your Compose model. Reach for `x-uds
 | `x-uds.network.allow[]` | Additional network allow rules — merged with (and deduplicated against) auto-generated rules. |
 | `x-uds.monitor[]` | Monitor rules for Prometheus scraping. When `service` is set, missing `selector`, `podSelector`, `portName`, `targetPort`, `path`, and `kind` are inferred from the Compose service. |
 | `x-uds.sso[]` | Override SSO clients — missing fields (`clientId`, `name`, `redirectUris`, `enableAuthserviceSelector`) are inferred. Set `x-uds.sso: []` to disable inferred SSO. |
-| `x-uds.caBundle.configMap` | Customize the operator-managed trust bundle ConfigMap metadata for this package namespace. Renders to `spec.caBundle` in `manifests/uds-package.yaml`. |
+| `x-uds.caBundle.configMap` | Customize the operator-managed trust bundle ConfigMap metadata for this package namespace. Renders to `spec.caBundle` in `chart/templates/uds-package.yaml`. |
 
 Example — override only the host for an exposed service:
 
@@ -128,14 +130,14 @@ See [`examples/full/compose.yaml`](examples/full/compose.yaml) for a complete wo
 ### Notes on specific keys
 
 - **Auto-expose port selection** — For services with multiple published ports, prefer Compose long syntax with `name` and/or `app_protocol` to identify the web-facing port, or use `x-uds.network.expose[].port` to pin the intended port if inference is ambiguous. The bridge does not automatically skip SSH, DNS, UDP, or other non-HTTP-looking ports.
-- **Bind mounts** — Bind mounts are treated as local-development-only inputs and are omitted from the rendered manifests with a warning. Conversion continues, which lets Compose files with dev container mounts still produce a deployable package. Use a named volume when the data should become a PVC, or a config/secret when the mounted content should be materialized in Kubernetes.
+- **Bind mounts** — Bind mounts are treated as local-development-only inputs and are omitted from the rendered chart with a warning. Conversion continues, which lets Compose files with dev container mounts still produce a deployable package. Use a named volume when the data should become a PVC, or a config/secret when the mounted content should be materialized in Kubernetes.
 - **`x-uds.sso`** — If omitted, the bridge infers an SSO client for the first exposed service. If explicitly set to an empty list (`x-uds.sso: []`), inferred SSO is disabled.
 - **`x-uds.monitor[]`** — Each entry may be a raw UDS `spec.monitor[]` item, or may use the bridge-only `service` key to infer labels and port metadata. For multi-port services, set either `portName` or `targetPort` so the bridge picks the intended metrics port.
 - **`x-uds.caBundle.configMap`** — Customizes the namespace trust-bundle ConfigMap created by UDS Core. The actual trust bundle contents are configured separately in UDS Core and are not part of the Package CR.
 
 ## UDS Exemption generation
 
-When Compose security settings conflict with UDS secure-by-default policies, the bridge writes `manifests/uds-exemption.yaml` with an `Exemption` scoped to each matching service's namespace and pod name pattern. No exemption file is emitted when all services are compliant.
+When Compose security settings conflict with UDS secure-by-default policies, the bridge writes `chart/templates/uds-exemption.yaml` with an `Exemption` scoped to each matching service's namespace and pod name pattern. No exemption file is emitted when all services are compliant.
 
 UDS Core enforces a restrictive baseline for workloads by default: containers are expected to run as non-root, avoid privileged mode, drop Linux capabilities, and use an approved seccomp profile. Those defaults are intentional defense-in-depth controls, but many Compose applications were written for a less constrained runtime. A container image that starts normally under Docker Compose may fail after package deploy if it expects root filesystem access, privileged host access, added capabilities, or an unconfined seccomp profile. In Kubernetes this often shows up as a pod stuck in `CrashLoopBackOff`, `CreateContainerConfigError`, or another startup failure caused by admission policy or missing permissions.
 

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -16,17 +16,23 @@ import (
 
 const zarfSchemaURL = "https://raw.githubusercontent.com/zarf-dev/zarf/main/zarf.schema.json"
 
-type composeComponentSpec struct {
-	Name          string
-	Namespace     string
-	ManifestFiles []string
-	Images        []string
-	DependsOn     []string
-}
+const (
+	// chartDirName is the Helm chart directory written under the package root.
+	chartDirName = "chart"
+	// zarfValuesRel is the Zarf-templated values file (relative to the package
+	// root) referenced by the component's chart valuesFiles. Only written when
+	// the package has secrets.
+	zarfValuesRel = "values/values.yaml"
+	// secretValuePlaceholder is the sentinel injected into a marshaled Secret's
+	// stringData and then replaced with a Helm value reference, so the Secret can
+	// be rendered by Helm from chart values rather than a static literal.
+	secretValuePlaceholder = "__HELM_SECRET_VALUE__"
+)
 
 func WritePackage(root string, app model.App) error {
-	manifestDir := filepath.Join(root, "manifests")
-	for _, dir := range []string{root, manifestDir} {
+	chartDir := filepath.Join(root, chartDirName)
+	templatesDir := filepath.Join(chartDir, "templates")
+	for _, dir := range []string{root, chartDir, templatesDir} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return fmt.Errorf("create directory %s: %w", dir, err)
 		}
@@ -40,8 +46,7 @@ func WritePackage(root string, app model.App) error {
 		}
 	}
 
-	namespaceRel := filepath.ToSlash(filepath.Join("manifests", "namespace.yaml"))
-	if err := writeYAMLFile(filepath.Join(manifestDir, "namespace.yaml"), namespaceManifest{
+	if err := writeYAMLFile(filepath.Join(templatesDir, "namespace.yaml"), namespaceManifest{
 		APIVersion: "v1",
 		Kind:       "Namespace",
 		Metadata: objectMeta{
@@ -54,14 +59,12 @@ func WritePackage(root string, app model.App) error {
 		return err
 	}
 
-	pvcManifestByName := map[string]string{}
 	for _, name := range sortedVolumeNames(app.Volumes) {
 		volume := app.Volumes[name]
 		if volume.External {
 			continue
 		}
-		relPath := filepath.ToSlash(filepath.Join("manifests", fmt.Sprintf("pvc-%s.yaml", volume.Name)))
-		if err := writeYAMLFile(filepath.Join(manifestDir, fmt.Sprintf("pvc-%s.yaml", volume.Name)), persistentVolumeClaimManifest{
+		if err := writeYAMLFile(filepath.Join(templatesDir, fmt.Sprintf("pvc-%s.yaml", volume.Name)), persistentVolumeClaimManifest{
 			APIVersion: "v1",
 			Kind:       "PersistentVolumeClaim",
 			Metadata: objectMeta{
@@ -76,17 +79,14 @@ func WritePackage(root string, app model.App) error {
 		}); err != nil {
 			return err
 		}
-		pvcManifestByName[name] = relPath
 	}
 
-	configManifestByName := map[string]string{}
 	for _, name := range sortedConfigNames(app.Configs) {
 		config := app.Configs[name]
 		if config.External {
 			continue
 		}
-		relPath := filepath.ToSlash(filepath.Join("manifests", fmt.Sprintf("configmap-%s.yaml", config.Name)))
-		if err := writeYAMLFile(filepath.Join(manifestDir, fmt.Sprintf("configmap-%s.yaml", config.Name)), configMapManifest{
+		if err := writeYAMLFile(filepath.Join(templatesDir, fmt.Sprintf("configmap-%s.yaml", config.Name)), configMapManifest{
 			APIVersion: "v1",
 			Kind:       "ConfigMap",
 			Metadata: objectMeta{
@@ -98,118 +98,135 @@ func WritePackage(root string, app model.App) error {
 		}); err != nil {
 			return err
 		}
-		configManifestByName[name] = relPath
 	}
 
-	secretManifestByName := map[string]string{}
+	// Secrets are rendered by Helm from chart values so Zarf can substitute the
+	// sensitive value into the values file at deploy time (Zarf only templates
+	// chart valuesFiles, not arbitrary template files). secretValueKeys tracks the
+	// values keys used so the chart defaults and the Zarf values file stay in sync.
+	secretValueKeys := make([]string, 0, len(app.Secrets))
 	for _, name := range sortedSecretNames(app.Secrets) {
 		secret := app.Secrets[name]
 		if secret.External {
 			continue
 		}
 		variableName := secretVariables[secret.Name]
-		relPath := filepath.ToSlash(filepath.Join("manifests", fmt.Sprintf("secret-%s.yaml", secret.Name)))
-		if err := writeYAMLFile(filepath.Join(manifestDir, fmt.Sprintf("secret-%s.yaml", secret.Name)), secretManifest{
-			APIVersion: "v1",
-			Kind:       "Secret",
-			Metadata: objectMeta{
-				Name:      secret.Name,
-				Namespace: app.Package.Namespace,
-				Labels:    appLabels(app.Package.Name, secret.Name),
-			},
-			Type:       "Opaque",
-			StringData: map[string]string{secret.Name: fmt.Sprintf("###ZARF_VAR_%s###", variableName)},
-		}); err != nil {
+		if err := writeSecretTemplate(filepath.Join(templatesDir, fmt.Sprintf("secret-%s.yaml", secret.Name)), app, secret, variableName); err != nil {
 			return err
 		}
-		secretManifestByName[name] = relPath
+		secretValueKeys = append(secretValueKeys, variableName)
 	}
 
-	components := make([]composeComponentSpec, 0, len(app.Services))
 	for _, svc := range app.Services {
-		manifestFiles := []string{namespaceRel}
-
-		for _, mount := range svc.Volumes {
-			if relPath, ok := pvcManifestByName[mount.Name]; ok {
-				manifestFiles = append(manifestFiles, relPath)
-			}
-		}
-		for _, ref := range svc.Secrets {
-			if relPath, ok := secretManifestByName[ref.Source]; ok {
-				manifestFiles = append(manifestFiles, relPath)
-			}
-		}
-		for _, ref := range svc.Configs {
-			if relPath, ok := configManifestByName[ref.Source]; ok {
-				manifestFiles = append(manifestFiles, relPath)
-			}
-		}
-
 		deployment, err := buildDeployment(app.Package.Name, app.Package.Namespace, svc, servicePorts)
 		if err != nil {
 			return err
 		}
-		deploymentRel := filepath.ToSlash(filepath.Join("manifests", fmt.Sprintf("deployment-%s.yaml", svc.Name)))
-		if err := writeYAMLFile(filepath.Join(manifestDir, fmt.Sprintf("deployment-%s.yaml", svc.Name)), deployment); err != nil {
+		if err := writeYAMLFile(filepath.Join(templatesDir, fmt.Sprintf("deployment-%s.yaml", svc.Name)), deployment); err != nil {
 			return err
 		}
-		manifestFiles = append(manifestFiles, deploymentRel)
-
-		serviceRel := filepath.ToSlash(filepath.Join("manifests", fmt.Sprintf("service-%s.yaml", svc.Name)))
-		if err := writeYAMLFile(filepath.Join(manifestDir, fmt.Sprintf("service-%s.yaml", svc.Name)), buildService(app.Package.Name, app.Package.Namespace, svc)); err != nil {
+		if err := writeYAMLFile(filepath.Join(templatesDir, fmt.Sprintf("service-%s.yaml", svc.Name)), buildService(app.Package.Name, app.Package.Namespace, svc)); err != nil {
 			return err
 		}
-		manifestFiles = append(manifestFiles, serviceRel)
-
-		component := composeComponentSpec{
-			Name:          svc.Name,
-			Namespace:     app.Package.Namespace,
-			ManifestFiles: dedupeStrings(manifestFiles),
-			Images:        buildComponentImages(svc, servicePorts),
-			DependsOn:     buildComponentDependsOn(svc),
-		}
-		components = append(components, component)
 	}
 
-	ordered, err := orderComposeComponents(components)
-	if err != nil {
-		return err
-	}
-
-	packageRel := filepath.ToSlash(filepath.Join("manifests", "uds-package.yaml"))
 	udsPackage, err := buildUDSPackage(app)
 	if err != nil {
 		return err
 	}
-	if err := writeYAMLFile(filepath.Join(manifestDir, "uds-package.yaml"), udsPackage); err != nil {
+	if err := writeYAMLFile(filepath.Join(templatesDir, "uds-package.yaml"), udsPackage); err != nil {
 		return err
-	}
-	if len(ordered) > 0 {
-		last := len(ordered) - 1
-		ordered[last].ManifestFiles = dedupeStrings(append(ordered[last].ManifestFiles, packageRel))
 	}
 
 	if exemption := buildUDSExemption(app); exemption != nil {
-		exemptionRel := filepath.ToSlash(filepath.Join("manifests", "uds-exemption.yaml"))
-		if err := writeYAMLFile(filepath.Join(manifestDir, "uds-exemption.yaml"), exemption); err != nil {
+		if err := writeYAMLFile(filepath.Join(templatesDir, "uds-exemption.yaml"), exemption); err != nil {
 			return err
-		}
-		if len(ordered) > 0 {
-			last := len(ordered) - 1
-			ordered[last].ManifestFiles = dedupeStrings(append(ordered[last].ManifestFiles, exemptionRel))
 		}
 	}
 
-	dedupeSharedManifests(ordered)
+	if err := writeChartMetadata(filepath.Join(chartDir, "Chart.yaml"), app); err != nil {
+		return err
+	}
+	if err := writeChartValues(filepath.Join(chartDir, "values.yaml"), secretValueKeys, false); err != nil {
+		return err
+	}
 
-	if err := writeZarfConfig(filepath.Join(root, "zarf.yaml"), app, secretVariables, ordered); err != nil {
+	hasSecrets := len(secretValueKeys) > 0
+	if hasSecrets {
+		valuesPath := filepath.Join(root, filepath.FromSlash(zarfValuesRel))
+		if err := os.MkdirAll(filepath.Dir(valuesPath), 0o755); err != nil {
+			return fmt.Errorf("create directory %s: %w", filepath.Dir(valuesPath), err)
+		}
+		if err := writeChartValues(valuesPath, secretValueKeys, true); err != nil {
+			return err
+		}
+	}
+
+	images := make([]string, 0, len(app.Services))
+	for _, svc := range app.Services {
+		images = append(images, buildComponentImages(svc, servicePorts)...)
+	}
+
+	if err := writeZarfConfig(filepath.Join(root, "zarf.yaml"), app, secretVariables, dedupeStrings(images), hasSecrets); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func writeZarfConfig(path string, app model.App, secretVariables map[string]string, components []composeComponentSpec) error {
+// writeSecretTemplate writes a Helm-templated Secret whose value is sourced from
+// chart values (.Values.secrets.<variableName>) rather than a static literal, so
+// Zarf can inject the sensitive value via the chart values file at deploy time.
+func writeSecretTemplate(path string, app model.App, secret model.Secret, variableName string) error {
+	data, err := yamlv3.Marshal(secretManifest{
+		APIVersion: "v1",
+		Kind:       "Secret",
+		Metadata: objectMeta{
+			Name:      secret.Name,
+			Namespace: app.Package.Namespace,
+			Labels:    appLabels(app.Package.Name, secret.Name),
+		},
+		Type:       "Opaque",
+		StringData: map[string]string{secret.Name: secretValuePlaceholder},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal yaml for %s: %w", path, err)
+	}
+	rendered := strings.ReplaceAll(string(data), secretValuePlaceholder,
+		fmt.Sprintf("{{ .Values.secrets.%s | quote }}", variableName))
+	if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil {
+		return fmt.Errorf("write file %s: %w", path, err)
+	}
+	return nil
+}
+
+// writeChartMetadata writes the generated chart's Chart.yaml.
+func writeChartMetadata(path string, app model.App) error {
+	return writeYAMLFile(path, chartMetadata{
+		APIVersion:  "v2",
+		Name:        app.Package.Name,
+		Description: fmt.Sprintf("UDS package generated from Docker Compose for %s", app.Package.Name),
+		Type:        "application",
+		Version:     app.Package.Version,
+		AppVersion:  app.Package.Version,
+	})
+}
+
+// writeChartValues writes a values document mapping each secret values key to a
+// default (empty) value, or to a Zarf variable placeholder when placeholder is set.
+func writeChartValues(path string, secretKeys []string, placeholder bool) error {
+	secrets := map[string]string{}
+	for _, key := range secretKeys {
+		if placeholder {
+			secrets[key] = fmt.Sprintf("###ZARF_VAR_%s###", key)
+		} else {
+			secrets[key] = ""
+		}
+	}
+	return writeYAMLFile(path, chartValues{Secrets: secrets})
+}
+
+func writeZarfConfig(path string, app model.App, secretVariables map[string]string, images []string, hasSecrets bool) error {
 	variables := []zarfVariable{}
 	for _, secretName := range sortedSecretNames(app.Secrets) {
 		variables = append(variables, zarfVariable{
@@ -231,21 +248,22 @@ func writeZarfConfig(path string, app model.App, secretVariables map[string]stri
 		Variables: variables,
 	}
 
-	for _, component := range components {
-		pkg.Components = append(pkg.Components, zarfComponent{
-			Name:        component.Name,
-			Required:    true,
-			Description: fmt.Sprintf("Deploy %s", component.Name),
-			Manifests: []zarfManifest{
-				{
-					Name:      component.Name + "-manifests",
-					Namespace: component.Namespace,
-					Files:     component.ManifestFiles,
-				},
-			},
-			Images: dedupeStrings(component.Images),
-		})
+	chart := zarfChart{
+		Name:      app.Package.Name,
+		Namespace: app.Package.Namespace,
+		LocalPath: chartDirName,
+		Version:   app.Package.Version,
 	}
+	if hasSecrets {
+		chart.ValuesFiles = []string{zarfValuesRel}
+	}
+	pkg.Components = append(pkg.Components, zarfComponent{
+		Name:        app.Package.Name,
+		Required:    true,
+		Description: fmt.Sprintf("Deploy %s", app.Package.Name),
+		Charts:      []zarfChart{chart},
+		Images:      dedupeStrings(images),
+	})
 
 	data, err := yamlv3.Marshal(pkg)
 	if err != nil {
@@ -852,14 +870,6 @@ func buildComponentImages(svc model.Service, servicePorts map[string]int) []stri
 	return dedupeStrings(images)
 }
 
-func buildComponentDependsOn(svc model.Service) []string {
-	dependsOn := make([]string, 0, len(svc.DependsOn))
-	for _, dep := range svc.DependsOn {
-		dependsOn = append(dependsOn, dep.Service)
-	}
-	return dedupeStrings(dependsOn)
-}
-
 func buildEnv(env []model.EnvVar) []envVar {
 	if len(env) == 0 {
 		return nil
@@ -1173,81 +1183,6 @@ func writeYAMLFile(path string, value any) error {
 	return nil
 }
 
-func dedupeSharedManifests(components []composeComponentSpec) {
-	claimed := map[string]struct{}{}
-	for i := range components {
-		unique := make([]string, 0, len(components[i].ManifestFiles))
-		for _, file := range components[i].ManifestFiles {
-			base := filepath.Base(file)
-			isShared := strings.HasPrefix(base, "secret-") || strings.HasPrefix(base, "configmap-") || strings.HasPrefix(base, "pvc-")
-			if isShared {
-				if _, exists := claimed[file]; exists {
-					continue
-				}
-				claimed[file] = struct{}{}
-			}
-			unique = append(unique, file)
-		}
-		components[i].ManifestFiles = unique
-	}
-}
-
-func orderComposeComponents(components []composeComponentSpec) ([]composeComponentSpec, error) {
-	if len(components) <= 1 {
-		return components, nil
-	}
-
-	componentByName := map[string]composeComponentSpec{}
-	indegree := map[string]int{}
-	dependents := map[string][]string{}
-	names := make([]string, 0, len(components))
-	for _, component := range components {
-		componentByName[component.Name] = component
-		indegree[component.Name] = 0
-		names = append(names, component.Name)
-	}
-
-	for _, component := range components {
-		for _, dep := range component.DependsOn {
-			if _, exists := componentByName[dep]; !exists {
-				continue
-			}
-			indegree[component.Name]++
-			dependents[dep] = append(dependents[dep], component.Name)
-		}
-	}
-
-	sort.Strings(names)
-	queue := make([]string, 0, len(names))
-	for _, name := range names {
-		if indegree[name] == 0 {
-			queue = append(queue, name)
-		}
-	}
-
-	ordered := make([]composeComponentSpec, 0, len(components))
-	for len(queue) > 0 {
-		current := queue[0]
-		queue = queue[1:]
-		ordered = append(ordered, componentByName[current])
-
-		next := append([]string(nil), dependents[current]...)
-		sort.Strings(next)
-		for _, dependent := range next {
-			indegree[dependent]--
-			if indegree[dependent] == 0 {
-				queue = append(queue, dependent)
-			}
-		}
-	}
-
-	if len(ordered) != len(components) {
-		return nil, fmt.Errorf("compose depends_on graph contains a cycle; unable to determine deterministic component order")
-	}
-
-	return ordered, nil
-}
-
 func sortedVolumeNames(volumes map[string]model.Volume) []string {
 	keys := make([]string, 0, len(volumes))
 	for key := range volumes {
@@ -1434,10 +1369,10 @@ type resourceRequirements struct {
 }
 
 type securityContext struct {
-	RunAsNonRoot *bool              `yaml:"runAsNonRoot,omitempty"`
-	RunAsUser    *int64             `yaml:"runAsUser,omitempty"`
-	Privileged   *bool              `yaml:"privileged,omitempty"`
-	Capabilities *capabilitiesSpec  `yaml:"capabilities,omitempty"`
+	RunAsNonRoot *bool             `yaml:"runAsNonRoot,omitempty"`
+	RunAsUser    *int64            `yaml:"runAsUser,omitempty"`
+	Privileged   *bool             `yaml:"privileged,omitempty"`
+	Capabilities *capabilitiesSpec `yaml:"capabilities,omitempty"`
 }
 
 type capabilitiesSpec struct {
@@ -1446,10 +1381,10 @@ type capabilitiesSpec struct {
 }
 
 type udsExemptionManifest struct {
-	APIVersion string             `yaml:"apiVersion"`
-	Kind       string             `yaml:"kind"`
-	Metadata   objectMeta         `yaml:"metadata"`
-	Spec       udsExemptionSpec   `yaml:"spec"`
+	APIVersion string           `yaml:"apiVersion"`
+	Kind       string           `yaml:"kind"`
+	Metadata   objectMeta       `yaml:"metadata"`
+	Spec       udsExemptionSpec `yaml:"spec"`
 }
 
 type udsExemptionSpec struct {
@@ -1457,9 +1392,9 @@ type udsExemptionSpec struct {
 }
 
 type udsExemptionEntry struct {
-	Title    string               `yaml:"title"`
-	Matcher  udsExemptionMatcher  `yaml:"matcher"`
-	Policies []string             `yaml:"policies"`
+	Title    string              `yaml:"title"`
+	Matcher  udsExemptionMatcher `yaml:"matcher"`
+	Policies []string            `yaml:"policies"`
 }
 
 type udsExemptionMatcher struct {
@@ -1561,15 +1496,33 @@ type zarfVariable struct {
 }
 
 type zarfComponent struct {
-	Name        string         `yaml:"name"`
-	Required    bool           `yaml:"required"`
-	Description string         `yaml:"description,omitempty"`
-	Manifests   []zarfManifest `yaml:"manifests,omitempty"`
-	Images      []string       `yaml:"images,omitempty"`
+	Name        string      `yaml:"name"`
+	Required    bool        `yaml:"required"`
+	Description string      `yaml:"description,omitempty"`
+	Charts      []zarfChart `yaml:"charts,omitempty"`
+	Images      []string    `yaml:"images,omitempty"`
 }
 
-type zarfManifest struct {
-	Name      string   `yaml:"name"`
-	Namespace string   `yaml:"namespace,omitempty"`
-	Files     []string `yaml:"files,omitempty"`
+type zarfChart struct {
+	Name        string   `yaml:"name"`
+	Namespace   string   `yaml:"namespace"`
+	LocalPath   string   `yaml:"localPath"`
+	Version     string   `yaml:"version"`
+	ValuesFiles []string `yaml:"valuesFiles,omitempty"`
+}
+
+// chartMetadata is the Chart.yaml written for the generated Helm chart.
+type chartMetadata struct {
+	APIVersion  string `yaml:"apiVersion"`
+	Name        string `yaml:"name"`
+	Description string `yaml:"description,omitempty"`
+	Type        string `yaml:"type,omitempty"`
+	Version     string `yaml:"version"`
+	AppVersion  string `yaml:"appVersion,omitempty"`
+}
+
+// chartValues is the values document written for both the chart defaults
+// (chart/values.yaml) and the Zarf-templated overrides (values/values.yaml).
+type chartValues struct {
+	Secrets map[string]string `yaml:"secrets"`
 }

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -149,12 +149,12 @@ configs:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	configMap := readFile(t, filepath.Join(outDir, "manifests", "configmap-app-config.yaml"))
+	configMap := readFile(t, filepath.Join(outDir, "chart", "templates", "configmap-app-config.yaml"))
 	if !strings.Contains(configMap, "key: value") {
 		t.Fatalf("expected configmap to contain rendered config content")
 	}
 
-	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	udsPackage := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	for _, want := range []string{
 		"namespace: demo-ns",
 		"service: api",
@@ -169,17 +169,16 @@ configs:
 
 	zarfConfig := readFile(t, filepath.Join(outDir, "zarf.yaml"))
 	for _, want := range []string{
-		"name: api",
+		"name: demo",
 		"namespace: demo-ns",
-		"manifests/uds-package.yaml",
-		"manifests/configmap-app-config.yaml",
+		"localPath: chart",
 	} {
 		if !strings.Contains(zarfConfig, want) {
-			t.Fatalf("expected zarf.yaml to contain %q", want)
+			t.Fatalf("expected zarf.yaml to contain %q\n%s", want, zarfConfig)
 		}
 	}
-	if strings.Contains(zarfConfig, "localPath: chart") {
-		t.Fatalf("did not expect chart-based zarf config")
+	if strings.Contains(zarfConfig, "manifests:") {
+		t.Fatalf("did not expect manifest-based zarf config\n%s", zarfConfig)
 	}
 }
 
@@ -210,7 +209,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	udsPackage := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	if !strings.Contains(udsPackage, "service: web") {
 		t.Fatalf("expected published web service to be auto-exposed")
 	}
@@ -240,7 +239,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	expose := firstExposeRule(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	expose := firstExposeRule(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	if got := expose["port"]; got != 3000 {
 		t.Fatalf("expected first declared published port 3000 to be auto-exposed, got %#v", got)
 	}
@@ -275,12 +274,12 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	expose := firstExposeRule(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	expose := firstExposeRule(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	if got := expose["port"]; got != 3000 {
 		t.Fatalf("expected app_protocol http port 3000 to be auto-exposed instead of SSH, got %#v", got)
 	}
 
-	service := readFile(t, filepath.Join(outDir, "manifests", "service-gitea.yaml"))
+	service := readFile(t, filepath.Join(outDir, "chart", "templates", "service-gitea.yaml"))
 	if !strings.Contains(service, "appProtocol: http") {
 		t.Fatalf("expected Service port to preserve app_protocol hint\n%s", service)
 	}
@@ -313,7 +312,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	expose := firstExposeRule(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	expose := firstExposeRule(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	if got := expose["port"]; got != 3000 {
 		t.Fatalf("expected web-named port 3000 to be auto-exposed instead of SSH, got %#v", got)
 	}
@@ -339,7 +338,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	expose := firstExposeRule(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	expose := firstExposeRule(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	if got := expose["port"]; got != 22 {
 		t.Fatalf("expected first declared published port 22 to remain eligible for auto-expose, got %#v", got)
 	}
@@ -365,12 +364,12 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	expose := firstExposeRule(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	expose := firstExposeRule(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	if got := expose["port"]; got != 53 {
 		t.Fatalf("expected UDP port 53 to remain eligible for auto-expose, got %#v", got)
 	}
 
-	service := readFile(t, filepath.Join(outDir, "manifests", "service-dns.yaml"))
+	service := readFile(t, filepath.Join(outDir, "chart", "templates", "service-dns.yaml"))
 	if !strings.Contains(service, "protocol: UDP") {
 		t.Fatalf("expected Service port to preserve UDP protocol\n%s", service)
 	}
@@ -403,7 +402,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	service := readFile(t, filepath.Join(outDir, "manifests", "service-web.yaml"))
+	service := readFile(t, filepath.Join(outDir, "chart", "templates", "service-web.yaml"))
 	for _, want := range []string{
 		"name: web-ui",
 		"name: port-9090-tcp",
@@ -441,7 +440,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	udsPackage := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	for _, want := range []string{
 		"service: web",
 		"host: web",
@@ -478,7 +477,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	udsPackage := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	for _, want := range []string{
 		"clientId: myapp",
 		"name: Myapp",
@@ -521,7 +520,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	udsPackage := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	if strings.Contains(udsPackage, "clientId:") {
 		t.Fatalf("did not expect SSO when x-uds.sso is explicitly empty\n%s", udsPackage)
 	}
@@ -564,7 +563,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	udsPackage := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	if !strings.Contains(udsPackage, "clientId: custom-id") {
 		t.Fatalf("expected user-provided clientId to be preserved\n%s", udsPackage)
 	}
@@ -596,7 +595,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	udsPackage := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	if strings.Contains(udsPackage, "clientId") {
 		t.Fatalf("did not expect SSO when no services have published ports\n%s", udsPackage)
 	}
@@ -626,7 +625,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	udsPackage := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	for _, want := range []string{
 		"monitor:",
 		"description: API metrics",
@@ -677,7 +676,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	udsPackage := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	for _, want := range []string{
 		"kind: PodMonitor",
 		"path: /custom/metrics",
@@ -720,7 +719,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	udsPackage := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	for _, want := range []string{
 		"targetPort: 9090",
 		"portName: port-9090-tcp",
@@ -761,7 +760,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	udsPackage := readFile(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	udsPackage := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	for _, want := range []string{
 		"selector:",
 		"podSelector:",
@@ -894,7 +893,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	udsPackage := readYAMLMap(t, filepath.Join(outDir, "manifests", "uds-package.yaml"))
+	udsPackage := readYAMLMap(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	spec := mustMap(t, udsPackage["spec"])
 	caBundle := mustMap(t, spec["caBundle"])
 	configMap := mustMap(t, caBundle["configMap"])
@@ -1018,7 +1017,7 @@ func TestExemptionForRootUser(t *testing.T) {
 				t.Fatalf("WritePackage() error = %v", err)
 			}
 
-			exemption := readFile(t, filepath.Join(outDir, "manifests", "uds-exemption.yaml"))
+			exemption := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-exemption.yaml"))
 			for _, want := range []string{
 				"kind: Exemption",
 				"namespace: uds-policy-exemptions",
@@ -1055,7 +1054,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	exemption := readFile(t, filepath.Join(outDir, "manifests", "uds-exemption.yaml"))
+	exemption := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-exemption.yaml"))
 	for _, want := range []string{
 		"kind: Exemption",
 		"namespace: uds-policy-exemptions",
@@ -1092,7 +1091,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	exemption := readFile(t, filepath.Join(outDir, "manifests", "uds-exemption.yaml"))
+	exemption := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-exemption.yaml"))
 	for _, want := range []string{
 		"DropAllCapabilities",
 		"RestrictCapabilities",
@@ -1124,7 +1123,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	exemption := readFile(t, filepath.Join(outDir, "manifests", "uds-exemption.yaml"))
+	exemption := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-exemption.yaml"))
 	if !strings.Contains(exemption, "RestrictSeccomp") {
 		t.Fatalf("expected RestrictSeccomp in exemption\n%s", exemption)
 	}
@@ -1149,7 +1148,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(outDir, "manifests", "uds-exemption.yaml")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(outDir, "chart", "templates", "uds-exemption.yaml")); !os.IsNotExist(err) {
 		t.Fatalf("expected uds-exemption.yaml to be absent for a secure service, stat err = %v", err)
 	}
 }
@@ -1174,7 +1173,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(outDir, "manifests", "uds-exemption.yaml")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(outDir, "chart", "templates", "uds-exemption.yaml")); !os.IsNotExist(err) {
 		t.Fatalf("expected uds-exemption.yaml to be absent for cap_drop-only service, stat err = %v", err)
 	}
 }
@@ -1206,7 +1205,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	exemption := readFile(t, filepath.Join(outDir, "manifests", "uds-exemption.yaml"))
+	exemption := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-exemption.yaml"))
 	for _, want := range []string{
 		"RequireNonRootUser",
 		"^gitea-.*",
@@ -1221,9 +1220,11 @@ services:
 		}
 	}
 
+	// The exemption is rendered as a chart template (not a path-referenced
+	// manifest), so the Zarf package references the generated chart instead.
 	zarfConfig := readFile(t, filepath.Join(outDir, "zarf.yaml"))
-	if !strings.Contains(zarfConfig, "manifests/uds-exemption.yaml") {
-		t.Fatalf("expected zarf.yaml to reference uds-exemption.yaml\n%s", zarfConfig)
+	if !strings.Contains(zarfConfig, "localPath: chart") {
+		t.Fatalf("expected zarf.yaml to reference the generated chart\n%s", zarfConfig)
 	}
 }
 
@@ -1247,7 +1248,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	deployment := readFile(t, filepath.Join(outDir, "manifests", "deployment-api.yaml"))
+	deployment := readFile(t, filepath.Join(outDir, "chart", "templates", "deployment-api.yaml"))
 	for _, want := range []string{
 		"capabilities:",
 		"drop:",
@@ -1257,6 +1258,125 @@ services:
 			t.Fatalf("expected deployment to contain %q\n%s", want, deployment)
 		}
 	}
+}
+
+func TestWritePackageGeneratesHelmChart(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: shop
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    ports:
+      - mode: ingress
+        target: 8080
+        published: "8080"
+        protocol: tcp
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	chartMeta := readFile(t, filepath.Join(outDir, "chart", "Chart.yaml"))
+	for _, want := range []string{
+		"apiVersion: v2",
+		"name: shop",
+		"version: 0.1.0",
+	} {
+		if !strings.Contains(chartMeta, want) {
+			t.Fatalf("expected Chart.yaml to contain %q\n%s", want, chartMeta)
+		}
+	}
+
+	// Resources are rendered as chart templates, not raw manifests.
+	for _, rel := range []string{"namespace.yaml", "deployment-api.yaml", "service-api.yaml", "uds-package.yaml"} {
+		if _, err := os.Stat(filepath.Join(outDir, "chart", "templates", rel)); err != nil {
+			t.Fatalf("expected chart template %s: %v", rel, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "manifests")); !os.IsNotExist(err) {
+		t.Fatalf("did not expect legacy manifests/ directory")
+	}
+
+	zarfConfig := readFile(t, filepath.Join(outDir, "zarf.yaml"))
+	for _, want := range []string{
+		"charts:",
+		"localPath: chart",
+		"name: shop",
+		"version: 0.1.0",
+	} {
+		if !strings.Contains(zarfConfig, want) {
+			t.Fatalf("expected zarf.yaml to contain %q\n%s", want, zarfConfig)
+		}
+	}
+	if strings.Contains(zarfConfig, "manifests:") {
+		t.Fatalf("did not expect manifest-based zarf config\n%s", zarfConfig)
+	}
+	// No secrets: no Zarf values file and no valuesFiles reference.
+	if _, err := os.Stat(filepath.Join(outDir, "values")); !os.IsNotExist(err) {
+		t.Fatalf("did not expect values/ directory for a package without secrets")
+	}
+	if strings.Contains(zarfConfig, "valuesFiles") {
+		t.Fatalf("did not expect valuesFiles for a package without secrets\n%s", zarfConfig)
+	}
+}
+
+func TestWritePackageSecretFlowsThroughChartValues(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: shop
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    secrets:
+      - api_key
+secrets:
+  api_key:
+    file: ./api_key.txt
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	// The Secret template reads from chart values, not a static literal.
+	secret := readFile(t, filepath.Join(outDir, "chart", "templates", "secret-api-key.yaml"))
+	if !strings.Contains(secret, "{{ .Values.secrets.API_KEY | quote }}") {
+		t.Fatalf("expected secret template to read from chart values\n%s", secret)
+	}
+	if strings.Contains(secret, "###ZARF_VAR_") {
+		t.Fatalf("did not expect Zarf placeholder inside chart template\n%s", secret)
+	}
+
+	// The Zarf variable placeholder lives in the Zarf-templated values file.
+	zarfValues := readFile(t, filepath.Join(outDir, "values", "values.yaml"))
+	if !strings.Contains(zarfValues, "API_KEY: '###ZARF_VAR_API_KEY###'") {
+		t.Fatalf("expected values.yaml to carry the variable placeholder\n%s", zarfValues)
+	}
+
+	zarfConfig := readFile(t, filepath.Join(outDir, "zarf.yaml"))
+	for _, want := range []string{
+		"valuesFiles:",
+		"values/values.yaml",
+		"name: API_KEY",
+		"sensitive: true",
+	} {
+		if !strings.Contains(zarfConfig, want) {
+			t.Fatalf("expected zarf.yaml to contain %q\n%s", want, zarfConfig)
+		}
+	}
+}
 
 func firstExposeRule(t *testing.T, path string) map[string]any {
 	t.Helper()


### PR DESCRIPTION
## Render Kubernetes resources as a Helm chart

### What & why

Per the UDS Package Requirements ("**SHOULD** use Helm charts for rendering Kubernetes resources"), the bridge now emits a **Helm chart** instead of raw manifests. Because resources are synthesized from Compose (no upstream chart exists), this is a single generated chart per package, with the UDS CRs rendered as templates alongside the workload resources. The Zarf package references it via a `charts:` (`localPath`) entry.

### Changes

- **Output layout**: `out/manifests/*.yaml` → `out/chart/` (`Chart.yaml`, `values.yaml`, `templates/*.yaml`), plus `out/values/values.yaml` when the package has secrets.
- **`zarf.yaml`**: collapsed from one component-per-service (`manifests:`) to a single component referencing the local chart via `charts: [{ localPath: chart, … }]`. Per-component topological ordering was dropped — runtime ordering is already handled by the existing `depends_on` init-containers.
- **Secrets**: now rendered from chart values so Zarf variable substitution still applies. Each `Secret` template reads `{{ .Values.secrets.<VAR> | quote }}`, and a Zarf-templated `out/values/values.yaml` (passed through `charts[].valuesFiles`) carries the `###ZARF_VAR_*###` placeholders. The `variables:` block (prompt + sensitive) is unchanged.
- Removed now-dead code: `orderComposeComponents`, `dedupeSharedManifests`, `buildComponentDependsOn`, and the `composeComponentSpec`/`zarfManifest` types.
- **Tests**: repointed paths to `chart/templates/`, updated `zarf.yaml` assertions to expect the chart reference, and added tests for the full chart structure (incl. the no-secrets case) and the secret-via-values flow. Also fixed a pre-existing missing-brace compile error in `TestCapDropUpdatesSecurityContext`.
- **README**: updated wording and path references; documented the Helm-chart rendering and secret/values flow.

### Verification

- `go vet`, `go build`, `go test ./...` pass.
- `helm lint` / `helm template` on the generated chart succeed.
- `zarf package create` on the regenerated `examples/simple` succeeds (processes the local Helm chart, pulls images, writes the package).