### PR TITLE
chore: add Renovate config for dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices"],
+  "minimumReleaseAge": "3 days",
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "minimumReleaseAge": null
+  },
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 10,
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "Go dependencies"
+    }
+  ]
+}


### PR DESCRIPTION
Keeps GitHub Actions and Docker base images current with supply-chain protection: 3-day minimum release age, vulnerability alerts bypass the age gate, Go deps grouped to reduce PR noise.