### PR TITLE
feat: use scratch for transformation runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,38 @@
-FROM golang:1.26@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647 AS builder
+# syntax=docker/dockerfile:1
+
+FROM --platform=$BUILDPLATFORM golang:1.26@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+
 WORKDIR /src
 
-COPY go.mod ./
-RUN go mod download
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(go env GOARCH) go build -o /out/transform ./
 
-FROM gcr.io/distroless/static-debian12:nonroot@sha256:f5b485ea962d9bd1186b2f6b3a061191539b905b82ec395de78cbfae51f20e35
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 \
+    GOOS="${TARGETOS}" \
+    GOARCH="${TARGETARCH}" \
+    go build \
+      -trimpath \
+      -buildvcs=false \
+      -ldflags="-s -w -buildid=" \
+      -o /transform \
+      .
+
+FROM scratch
+
 LABEL com.docker.compose.bridge=transformation
-COPY --from=builder /out/transform /transform
+
+COPY --from=builder \
+     --chown=65532:65532 \
+     --chmod=0555 \
+     /transform /transform
+
+USER 65532:65532
+
 ENTRYPOINT ["/transform"]


### PR DESCRIPTION
Slim down the runtime image using `scratch`