### PR TITLE
feat: add support for build only services

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Convert a Docker Compose application into a deployable [UDS](https://uds.defense
 
 ## Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/) with Docker Compose v5.5.0 or later
+- [Docker](https://docs.docker.com/get-docker/) with [Docker Compose](https://github.com/docker/compose) v5.5.0 or later
 - [k3d](https://k3d.io/stable/#releases)
 - [UDS CLI](https://uds.defenseunicorns.com/reference/cli/quickstart-and-usage/)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Convert a Docker Compose application into a deployable [UDS](https://uds.defense
 
 ## Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/) with [Docker Compose](https://github.com/docker/compose) v5.5.0 or later
+- [Docker](https://docs.docker.com/get-docker/) with [Docker Compose](https://github.com/docker/compose) (v5.5.0 or later is recommended for build-only services)
 - [k3d](https://k3d.io/stable/#releases)
 - [UDS CLI](https://uds.defenseunicorns.com/reference/cli/quickstart-and-usage/)
 
@@ -30,7 +30,7 @@ zarf package create out/
 zarf package deploy zarf-package-wordpress-*.tar.zst
 ```
 
-The transformation writes a Helm chart to `out/chart/`, a Zarf package definition to `out/zarf.yaml`, and `out/values/` when the Compose file declares secrets. Services with `build:` are built during `zarf package create` through a generated Buildx Bake definition, so no separate `docker compose build` step is required.
+The transformation writes a Helm chart to `out/chart/`, a Zarf package definition to `out/zarf.yaml`, and `out/values/` when the Compose file declares secrets. Services with `build:` are built during `zarf package create` through a generated Buildx Bake definition. See [Compose support](docs/compose-support.md#local-dockerfile-builds) for Docker Compose version-specific conversion steps.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Convert a Docker Compose application into a deployable [UDS](https://uds.defense
 
 ## Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/)
+- [Docker](https://docs.docker.com/get-docker/) with Docker Compose v5.5.0 or later
 - [k3d](https://k3d.io/stable/#releases)
 - [UDS CLI](https://uds.defenseunicorns.com/reference/cli/quickstart-and-usage/)
 
@@ -30,7 +30,7 @@ zarf package create out/
 zarf package deploy zarf-package-wordpress-*.tar.zst
 ```
 
-The transformation writes a Helm chart to `out/chart/`, a Zarf package definition to `out/zarf.yaml`, and `out/values/` when the Compose file declares secrets.
+The transformation writes a Helm chart to `out/chart/`, a Zarf package definition to `out/zarf.yaml`, and `out/values/` when the Compose file declares secrets. Services with `build:` are built during `zarf package create` through a generated Buildx Bake definition, so no separate `docker compose build` step is required.
 
 ## Documentation
 

--- a/docs/awesome-compose-compatibility-matrix.md
+++ b/docs/awesome-compose-compatibility-matrix.md
@@ -18,10 +18,10 @@ the tested baseline and Results table below.
 <!-- matrix-baseline:start -->
 | Input | Value |
 |---|---|
-| Compose Bridge | `bff5ab4c3e197955983cb15f72e5c34b24a7cb50` |
+| Compose Bridge | `fc9f1dc89cffbbc4c3c9cff436250cdb0281e4b3` |
 | Awesome Compose | [`30f4b7f6a6c3b0c0ecf4d4efb0de203c48d11562`](https://github.com/docker/awesome-compose/commit/30f4b7f6a6c3b0c0ecf4d4efb0de203c48d11562) |
-| Docker Compose | `5.1.2` |
-| Go | `go1.26.5 darwin/arm64` |
+| Docker Compose | `5.5.0` |
+| Go | `go1.26.4 darwin/arm64` |
 
 All 39 files canonicalized. The bridge supported and rendered 30 models and rejected 9 with diagnostics.
 <!-- matrix-baseline:end -->

--- a/docs/compose-support.md
+++ b/docs/compose-support.md
@@ -5,7 +5,7 @@
 | Compose key                                                      | Behavior                                                                                                                                                                                                                                                                        |
 | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `image:`                                                         | Container image reference.                                                                                                                                                                                                                                                      |
-| `build:`                                                         | Build from a Dockerfile. Run `docker compose build` before `docker compose bridge convert`; the bridge conversion does not build images.                                                                                                                                        |
+| `build:`                                                         | Preserved as a generated Buildx Bake definition. `zarf package create` builds the image and adds its OCI archive to the package.                                                                                                                                                |
 | Named `volumes:`                                                 | Converted to PersistentVolumeClaims (`1Gi`, `ReadWriteOnce` by default).                                                                                                                                                                                                        |
 | `secrets:`                                                       | Converted to Kubernetes Secrets.                                                                                                                                                                                                                                                |
 | `configs:`                                                       | Converted to ConfigMaps. Must use inline `content:` (no external file references).                                                                                                                                                                                              |
@@ -25,15 +25,19 @@ External configs are not supported. A `configs:` entry must define inline `conte
 
 ## Local Dockerfile builds
 
-Docker Compose Bridge does not run the Compose build step. If a service uses `build:` with a local Dockerfile, build the Compose project before running the bridge conversion so the image exists locally:
+Docker Compose v5.5.0 or later can pass a build-only service through Compose Bridge without trying to pull Compose's default image name. This means a service can use `build:` without declaring `image:`:
 
 ```sh
 cd examples/full
-docker compose build
 docker compose bridge convert -t ghcr.io/defenseunicorns-labs/compose-bridge-uds
+zarf package create out
 ```
 
-When `image:` is omitted, Compose assigns a default image name based on the project and service, such as `hello-world-server` for `examples/full`. Compose Bridge resolves that built image before invoking the transformation. Declare `image:` when the generated Helm chart and `zarf.yaml` need a stable or registry-backed reference.
+The bridge assigns each build service a package-local image reference, writes the canonical build configuration to `out/build.compose.yaml`, and adds Zarf `onCreate` actions that run `docker buildx bake`. The build produces OCI archives under `out/image-archives/`, which Zarf includes through `imageArchives`. User-provided build tags do not become additional package image references.
+
+Local contexts, Dockerfiles, additional contexts, build-secret files, and SSH paths are passed to Buildx as explicit filesystem read allowances. Build services default to `linux/amd64` and `linux/arm64`; a Compose `build.platforms` declaration overrides that default for the service.
+
+Deferred builds cannot automatically determine what to expose by examining the Dockerfile because the image is built after Compose Bridge conversion.
 
 ## Configuration notes
 

--- a/docs/compose-support.md
+++ b/docs/compose-support.md
@@ -35,7 +35,9 @@ zarf package create out
 
 The bridge assigns each build service a package-local image reference, writes the canonical build configuration to `out/build.compose.yaml`, and adds Zarf `onCreate` actions that run `docker buildx bake`. The build produces OCI archives under `out/image-archives/`, which Zarf includes through `imageArchives`. User-provided build tags do not become additional package image references.
 
-Local contexts, Dockerfiles, additional contexts, build-secret files, and SSH paths are passed to Buildx as explicit filesystem read allowances. Build services default to `linux/amd64` and `linux/arm64`; a Compose `build.platforms` declaration overrides that default for the service.
+Local contexts, Dockerfiles, additional contexts, build-secret files, and SSH paths are passed to Buildx as explicit filesystem read allowances. 
+
+Build services default to `linux/amd64` and `linux/arm64`; a Compose `build.platforms` declaration overrides that default for the service.
 
 Deferred builds cannot automatically determine what to expose by examining the Dockerfile because the image is built after Compose Bridge conversion.
 

--- a/docs/compose-support.md
+++ b/docs/compose-support.md
@@ -25,13 +25,26 @@ External configs are not supported. A `configs:` entry must define inline `conte
 
 ## Local Dockerfile builds
 
-Docker Compose v5.5.0 or later can pass a build-only service through Compose Bridge without trying to pull Compose's default image name. This means a service can use `build:` without declaring `image:`:
+Docker Compose v5.5.0 or later can pass a build-only service through Compose Bridge without trying to pull Compose's default image name. For earlier Compose versions, run `docker compose build` before conversion so that default image exists locally:
+
+### Docker Compose versions earlier than v5.5.0
+
+```sh
+cd examples/full
+docker compose build
+docker compose bridge convert -t ghcr.io/defenseunicorns-labs/compose-bridge-uds
+zarf package create out
+```
+
+### Docker Compose versions v5.5.0 or later
 
 ```sh
 cd examples/full
 docker compose bridge convert -t ghcr.io/defenseunicorns-labs/compose-bridge-uds
 zarf package create out
 ```
+
+With Docker Compose versions earlier than v5.5.0, the `docker compose build` step is required to unblock conversion; Zarf still runs the generated Buildx Bake build during `zarf package create`.
 
 The bridge assigns each build service a package-local image reference, writes the canonical build configuration to `out/build.compose.yaml`, and adds Zarf `onCreate` actions that run `docker buildx bake`. The build produces OCI archives under `out/image-archives/`, which Zarf includes through `imageArchives`. User-provided build tags do not become additional package image references.
 

--- a/docs/uds-package.md
+++ b/docs/uds-package.md
@@ -2,6 +2,8 @@
 
 The bridge maps the [Compose Specification](https://compose-spec.io/) to Kubernetes resources and synthesizes a [UDS Package CR](https://docs.defenseunicorns.com/core/reference/operator--crds/packages-v1alpha1-cr/) for network policy, monitoring, SSO, and trust-bundle distribution. It renders these resources as a Helm chart under `out/chart/`, referenced by `out/zarf.yaml` with `localPath: chart`.
 
+For services with `build:`, the bridge also writes `out/build.compose.yaml`. Zarf `onCreate` actions use Buildx Bake to build those services into OCI archives under `out/image-archives/`, and the component's `imageArchives` entries add them to the package.
+
 Secrets are rendered from chart values rather than baked into templates. The bridge writes `out/values/values.yaml` with `###ZARF_VAR_*###` placeholders, references it through `charts[].valuesFiles`, and retains the prompt and sensitivity settings in the Zarf package's `variables:`.
 
 ## Inferred behavior

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -115,7 +115,7 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 	if err != nil {
 		return model.App{}, err
 	}
-	declaredSecrets, secretAliases, err := normalizeTopLevelSecrets(project.Secrets)
+	secrets, secretAliases, err := normalizeTopLevelSecrets(project.Secrets)
 	if err != nil {
 		return model.App{}, err
 	}
@@ -146,7 +146,7 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 
 	services := make([]model.Service, 0, len(keys))
 	buildSecretNames := map[string]struct{}{}
-	secretNames := map[string]struct{}{}
+	serviceSecretNames := map[string]struct{}{}
 
 	for _, key := range keys {
 		rawSvc := project.Services[key]
@@ -169,7 +169,7 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 			return model.App{}, fmt.Errorf("service %q secrets: %w", key, err)
 		}
 		for _, secret := range secretRefs {
-			secretNames[secret.Source] = struct{}{}
+			serviceSecretNames[secret.Source] = struct{}{}
 		}
 		configRefs, err := parseServiceConfigs(rawSvc.Configs, configAliases)
 		if err != nil {
@@ -232,10 +232,15 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 			return model.App{}, fmt.Errorf("build secret %q is missing from the canonical Compose model", name)
 		}
 		buildSecrets[name] = definition
-	}
-	secrets := map[string]model.Secret{}
-	for name := range secretNames {
-		secrets[name] = declaredSecrets[name]
+		// Build-only secrets are inputs to Buildx, not secrets used by the
+		// deployed application. Keep secrets that are used in both places.
+		secretName, ok := resolveAlias(secretAliases, name)
+		if !ok {
+			return model.App{}, fmt.Errorf("build secret %q is missing from the Compose model", name)
+		}
+		if _, usedByService := serviceSecretNames[secretName]; !usedByService {
+			delete(secrets, secretName)
+		}
 	}
 
 	return model.App{

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -75,10 +75,6 @@ func loadCanonicalYAML(data []byte, sourcePath string) (model.App, error) {
 
 func loadWorkingDir(sourcePath string) string {
 	if sourcePath != "" {
-		dir, err := filepath.Abs(filepath.Dir(sourcePath))
-		if err == nil {
-			return dir
-		}
 		return filepath.Dir(sourcePath)
 	}
 	wd, err := os.Getwd()
@@ -145,8 +141,7 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 	}
 
 	services := make([]model.Service, 0, len(keys))
-	buildSecretNames := map[string]struct{}{}
-	serviceSecretNames := map[string]struct{}{}
+	buildSecrets := map[string]any{}
 
 	for _, key := range keys {
 		rawSvc := project.Services[key]
@@ -167,9 +162,6 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 		secretRefs, err := parseServiceSecrets(rawSvc.Secrets, secretAliases)
 		if err != nil {
 			return model.App{}, fmt.Errorf("service %q secrets: %w", key, err)
-		}
-		for _, secret := range secretRefs {
-			serviceSecretNames[secret.Source] = struct{}{}
 		}
 		configRefs, err := parseServiceConfigs(rawSvc.Configs, configAliases)
 		if err != nil {
@@ -193,9 +185,15 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 				ReadPaths: buildReadPaths(rawSvc.Build, project.Secrets),
 			}
 			for _, secret := range rawSvc.Build.Secrets {
-				if source := strings.TrimSpace(secret.Source); source != "" {
-					buildSecretNames[source] = struct{}{}
+				source := strings.TrimSpace(secret.Source)
+				if source == "" {
+					continue
 				}
+				definition, ok := canonicalSecrets[source]
+				if !ok {
+					return model.App{}, fmt.Errorf("build secret %q is missing from the canonical Compose model", source)
+				}
+				buildSecrets[source] = definition
 			}
 		}
 
@@ -223,24 +221,6 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 			Resources:    parseResources(rawSvc.Deploy),
 			Profiles:     normalizeProfiles(rawSvc.Profiles),
 		})
-	}
-
-	buildSecrets := map[string]any{}
-	for name := range buildSecretNames {
-		definition, ok := canonicalSecrets[name]
-		if !ok {
-			return model.App{}, fmt.Errorf("build secret %q is missing from the canonical Compose model", name)
-		}
-		buildSecrets[name] = definition
-		// Build-only secrets are inputs to Buildx, not secrets used by the
-		// deployed application. Keep secrets that are used in both places.
-		secretName, ok := resolveAlias(secretAliases, name)
-		if !ok {
-			return model.App{}, fmt.Errorf("build secret %q is missing from the Compose model", name)
-		}
-		if _, usedByService := serviceSecretNames[secretName]; !usedByService {
-			delete(secrets, secretName)
-		}
 	}
 
 	return model.App{

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -75,6 +75,10 @@ func loadCanonicalYAML(data []byte, sourcePath string) (model.App, error) {
 
 func loadWorkingDir(sourcePath string) string {
 	if sourcePath != "" {
+		dir, err := filepath.Abs(filepath.Dir(sourcePath))
+		if err == nil {
+			return dir
+		}
 		return filepath.Dir(sourcePath)
 	}
 	wd, err := os.Getwd()
@@ -135,8 +139,14 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 		registerAlias(serviceAliases, key, normalized)
 		registerAlias(serviceAliases, normalized, normalized)
 	}
+	canonicalServices, canonicalSecrets, err := canonicalBuildMaps(project)
+	if err != nil {
+		return model.App{}, err
+	}
 
 	services := make([]model.Service, 0, len(keys))
+	buildSecretNames := map[string]struct{}{}
+	runtimeSecretNames := map[string]struct{}{}
 
 	for _, key := range keys {
 		rawSvc := project.Services[key]
@@ -158,6 +168,9 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 		if err != nil {
 			return model.App{}, fmt.Errorf("service %q secrets: %w", key, err)
 		}
+		for _, secret := range secretRefs {
+			runtimeSecretNames[secret.Source] = struct{}{}
+		}
 		configRefs, err := parseServiceConfigs(rawSvc.Configs, configAliases)
 		if err != nil {
 			return model.App{}, fmt.Errorf("service %q configs: %w", key, err)
@@ -168,12 +181,28 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 		}
 
 		image := strings.TrimSpace(rawSvc.Image)
-		usesBuild := rawSvc.Build != nil
+		var build *model.BuildDefinition
+		if rawSvc.Build != nil {
+			buildConfig, err := canonicalBuildConfig(canonicalServices, key, serviceAliases)
+			if err != nil {
+				return model.App{}, err
+			}
+			image = builtImageReference(packageCfg, serviceName)
+			build = &model.BuildDefinition{
+				Config:    buildConfig,
+				ReadPaths: buildReadPaths(rawSvc.Build, project.Secrets),
+			}
+			for _, secret := range rawSvc.Build.Secrets {
+				if source := strings.TrimSpace(secret.Source); source != "" {
+					buildSecretNames[source] = struct{}{}
+				}
+			}
+		}
 
 		services = append(services, model.Service{
 			Name:         serviceName,
 			Image:        image,
-			UsesBuild:    usesBuild,
+			Build:        build,
 			Ports:        ports,
 			Networks:     networks,
 			Env:          parseEnvironment(rawSvc.Environment),
@@ -196,13 +225,141 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 		})
 	}
 
+	buildSecrets := map[string]any{}
+	for name := range buildSecretNames {
+		definition, ok := canonicalSecrets[name]
+		if !ok {
+			return model.App{}, fmt.Errorf("build secret %q is missing from the canonical Compose model", name)
+		}
+		buildSecrets[name] = definition
+	}
+	runtimeSecrets := map[string]model.Secret{}
+	for name := range runtimeSecretNames {
+		runtimeSecrets[name] = secrets[name]
+	}
+
 	return model.App{
-		Package:  packageCfg,
-		Services: services,
-		Volumes:  volumes,
-		Secrets:  secrets,
-		Configs:  configs,
+		Package:      packageCfg,
+		Services:     services,
+		Volumes:      volumes,
+		Secrets:      runtimeSecrets,
+		Configs:      configs,
+		BuildSecrets: buildSecrets,
 	}, nil
+}
+
+func canonicalBuildMaps(project types.Project) (map[string]any, map[string]any, error) {
+	data, err := project.MarshalYAML()
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal canonical Compose build model: %w", err)
+	}
+	var canonical map[string]any
+	if err := yamlv3.Unmarshal(data, &canonical); err != nil {
+		return nil, nil, fmt.Errorf("decode canonical Compose build model: %w", err)
+	}
+	services, _ := asMap(canonical["services"])
+	secrets, _ := asMap(canonical["secrets"])
+	return services, secrets, nil
+}
+
+func canonicalBuildConfig(services map[string]any, serviceName string, aliases map[string]string) (map[string]any, error) {
+	service, ok := asMap(services[serviceName])
+	if !ok {
+		return nil, fmt.Errorf("service %q is missing from the canonical Compose build model", serviceName)
+	}
+	build, ok := asMap(service["build"])
+	if !ok {
+		return nil, fmt.Errorf("service %q has no canonical Compose build definition", serviceName)
+	}
+
+	// Compose build.tags would add extra, user-controlled references to the OCI
+	// archive. Built services always use the bridge-controlled internal image.
+	delete(build, "tags")
+	if contexts, ok := asMap(build["additional_contexts"]); ok {
+		for name, value := range contexts {
+			reference, ok := value.(string)
+			if !ok || !strings.HasPrefix(reference, "service:") {
+				continue
+			}
+			if resolved, ok := resolveAlias(aliases, strings.TrimPrefix(reference, "service:")); ok {
+				contexts[name] = "service:" + resolved
+			}
+		}
+	}
+	return build, nil
+}
+
+func builtImageReference(pkg model.Package, serviceName string) string {
+	return fmt.Sprintf("zarf.internal/%s-%s:%s", pkg.Name, serviceName, sanitizeImageTag(pkg.Version))
+}
+
+func buildReadPaths(build *types.BuildConfig, secrets types.Secrets) []string {
+	paths := map[string]struct{}{}
+	addBuildReadPath(paths, build.Context, false)
+	for _, context := range build.AdditionalContexts {
+		addBuildReadPath(paths, context, false)
+	}
+	if build.Dockerfile != "" {
+		switch {
+		case filepath.IsAbs(build.Dockerfile):
+			addBuildReadPath(paths, build.Dockerfile, true)
+		case isLocalBuildPath(build.Context):
+			addBuildReadPath(paths, filepath.Join(build.Context, build.Dockerfile), true)
+		}
+	}
+	for _, secret := range build.Secrets {
+		if definition, ok := secrets[secret.Source]; ok {
+			addBuildReadPath(paths, definition.File, true)
+		}
+	}
+	for _, ssh := range build.SSH {
+		addBuildReadPath(paths, ssh.Path, true)
+	}
+
+	result := make([]string, 0, len(paths))
+	for path := range paths {
+		result = append(result, path)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func addBuildReadPath(paths map[string]struct{}, value string, useParent bool) {
+	if !isLocalBuildPath(value) {
+		return
+	}
+	path := filepath.Clean(strings.TrimSpace(value))
+	if useParent {
+		path = filepath.Dir(path)
+	}
+	paths[path] = struct{}{}
+}
+
+func isLocalBuildPath(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.Contains(value, "://") {
+		return false
+	}
+	for _, prefix := range []string{"service:", "target:", "docker-image:", "oci-layout:"} {
+		if strings.HasPrefix(value, prefix) {
+			return false
+		}
+	}
+	return true
+}
+
+var invalidImageTagChars = regexp.MustCompile(`[^A-Za-z0-9_.-]+`)
+
+func sanitizeImageTag(value string) string {
+	tag := invalidImageTagChars.ReplaceAllString(strings.TrimSpace(value), "-")
+	tag = strings.TrimLeft(tag, ".-")
+	if tag == "" {
+		tag = "latest"
+	}
+	if len(tag) > 128 {
+		tag = tag[:128]
+	}
+	return tag
 }
 
 func parsePackageConfig(projectName string, raw map[string]any) (model.Package, error) {

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -115,7 +115,7 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 	if err != nil {
 		return model.App{}, err
 	}
-	secrets, secretAliases, err := normalizeTopLevelSecrets(project.Secrets)
+	declaredSecrets, secretAliases, err := normalizeTopLevelSecrets(project.Secrets)
 	if err != nil {
 		return model.App{}, err
 	}
@@ -146,7 +146,7 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 
 	services := make([]model.Service, 0, len(keys))
 	buildSecretNames := map[string]struct{}{}
-	runtimeSecretNames := map[string]struct{}{}
+	secretNames := map[string]struct{}{}
 
 	for _, key := range keys {
 		rawSvc := project.Services[key]
@@ -169,7 +169,7 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 			return model.App{}, fmt.Errorf("service %q secrets: %w", key, err)
 		}
 		for _, secret := range secretRefs {
-			runtimeSecretNames[secret.Source] = struct{}{}
+			secretNames[secret.Source] = struct{}{}
 		}
 		configRefs, err := parseServiceConfigs(rawSvc.Configs, configAliases)
 		if err != nil {
@@ -233,16 +233,16 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 		}
 		buildSecrets[name] = definition
 	}
-	runtimeSecrets := map[string]model.Secret{}
-	for name := range runtimeSecretNames {
-		runtimeSecrets[name] = secrets[name]
+	secrets := map[string]model.Secret{}
+	for name := range secretNames {
+		secrets[name] = declaredSecrets[name]
 	}
 
 	return model.App{
 		Package:      packageCfg,
 		Services:     services,
 		Volumes:      volumes,
-		Secrets:      runtimeSecrets,
+		Secrets:      secrets,
 		Configs:      configs,
 		BuildSecrets: buildSecrets,
 	}, nil

--- a/internal/compose/compatibility.go
+++ b/internal/compose/compatibility.go
@@ -67,7 +67,7 @@ func validateCompatibility(project types.Project, raw map[string]any) error {
 			issues = append(issues, CompatibilityIssue{
 				Code:        "image-required",
 				Path:        path + ".image",
-				Message:     "the service has no container image or build definition",
+				Message:     "the service has no container image",
 				Remediation: "declare `image:` or `build:`",
 			})
 		}

--- a/internal/compose/compatibility.go
+++ b/internal/compose/compatibility.go
@@ -63,22 +63,13 @@ func validateCompatibility(project types.Project, raw map[string]any) error {
 		path := "services." + serviceName
 		rawService, _ := asMap(rawServices[serviceName])
 
-		if strings.TrimSpace(service.Image) == "" {
-			if service.Build != nil {
-				issues = append(issues, CompatibilityIssue{
-					Code:        "build-image-unresolved",
-					Path:        path + ".image",
-					Message:     "the local build image was not resolved by Compose Bridge",
-					Remediation: "run `docker compose build` before conversion or declare `image:` explicitly",
-				})
-			} else {
-				issues = append(issues, CompatibilityIssue{
-					Code:        "image-required",
-					Path:        path + ".image",
-					Message:     "the service has no container image",
-					Remediation: "declare `image:` or `build:`",
-				})
-			}
+		if strings.TrimSpace(service.Image) == "" && service.Build == nil {
+			issues = append(issues, CompatibilityIssue{
+				Code:        "image-required",
+				Path:        path + ".image",
+				Message:     "the service has no container image or build definition",
+				Remediation: "declare `image:` or `build:`",
+			})
 		}
 
 		for _, mount := range service.Volumes {

--- a/internal/compose/compatibility.go
+++ b/internal/compose/compatibility.go
@@ -67,7 +67,7 @@ func validateCompatibility(project types.Project, raw map[string]any) error {
 			issues = append(issues, CompatibilityIssue{
 				Code:        "image-required",
 				Path:        path + ".image",
-				Message:     "the service has no container image",
+				Message:     "the service has no container image or build definition",
 				Remediation: "declare `image:` or `build:`",
 			})
 		}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -105,10 +105,18 @@ type Package struct {
 	CABundle        map[string]any
 }
 
+type BuildDefinition struct {
+	// Config keeps the canonical Compose build fields as generic YAML data so
+	// new Compose build options can pass through without duplicating its schema.
+	Config map[string]any
+	// ReadPaths lists host directories Buildx Bake must be allowed to access.
+	ReadPaths []string
+}
+
 type Service struct {
 	Name         string
 	Image        string
-	UsesBuild    bool
+	Build        *BuildDefinition
 	Ports        []Port
 	Networks     []string
 	Env          []EnvVar
@@ -131,11 +139,12 @@ type Service struct {
 }
 
 type App struct {
-	Package  Package
-	Services []Service
-	Volumes  map[string]Volume
-	Secrets  map[string]Secret
-	Configs  map[string]Config
+	Package      Package
+	Services     []Service
+	Volumes      map[string]Volume
+	Secrets      map[string]Secret
+	Configs      map[string]Config
+	BuildSecrets map[string]any
 }
 
 func (s Service) PrimaryPort() (Port, error) {

--- a/internal/render/buildx_test.go
+++ b/internal/render/buildx_test.go
@@ -1,0 +1,82 @@
+package render_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"defenseunicorns/uds-compose-bridge/internal/compose"
+	"defenseunicorns/uds-compose-bridge/internal/render"
+)
+
+func TestGeneratedBuildComposePassesBuildxBakePrint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Buildx integration test in short mode")
+	}
+
+	dockerPath, err := exec.LookPath("docker")
+	if err != nil {
+		t.Skip("docker CLI is not installed")
+	}
+	if output, err := exec.Command(dockerPath, "buildx", "version").CombinedOutput(); err != nil {
+		t.Skipf("Docker Buildx is not available: %v: %s", err, output)
+	}
+
+	sourceDir := t.TempDir()
+	composePath := filepath.Join(sourceDir, "compose.yaml")
+	if err := os.WriteFile(composePath, []byte(`name: bake-integration
+services:
+  server:
+    build:
+      context: .
+      args:
+        MESSAGE: hello
+`), 0o644); err != nil {
+		t.Fatalf("write compose fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile fixture: %v", err)
+	}
+
+	app, err := compose.LoadCanonicalFile(composePath)
+	if err != nil {
+		t.Fatalf("LoadCanonicalFile() error = %v", err)
+	}
+	outDir := filepath.Join(sourceDir, "out")
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	archive := filepath.ToSlash(filepath.Join("image-archives", "server.tar"))
+	command := exec.Command(dockerPath,
+		"buildx", "bake",
+		"--file", "build.compose.yaml",
+		"--allow", "fs.read="+sourceDir,
+		"--set", "server.platform+=linux/amd64",
+		"--set", "server.platform+=linux/arm64",
+		"--set", "server.output=type=oci,dest="+archive,
+		"--print",
+		"server",
+	)
+	command.Dir = outDir
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("docker buildx bake --print rejected generated build definition: %v\n%s", err, output)
+	}
+
+	printed := string(output)
+	for _, want := range []string{
+		`"server"`,
+		`"zarf.internal/bake-integration-server:0.1.0"`,
+		`"linux/amd64"`,
+		`"linux/arm64"`,
+		`"dest": "image-archives/server.tar"`,
+		`"type": "oci"`,
+	} {
+		if !strings.Contains(printed, want) {
+			t.Fatalf("expected Buildx Bake output to contain %q\n%s", want, printed)
+		}
+	}
+}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -177,12 +177,7 @@ func WritePackage(root string, app model.App) error {
 
 	images := make([]string, 0, len(app.Services))
 	for _, svc := range app.Services {
-		if svc.Build == nil {
-			images = append(images, svc.Image)
-		}
-		if len(buildDependencyInitContainers(svc, servicePorts)) > 0 {
-			images = append(images, model.DependencyInitImage)
-		}
+		images = append(images, buildComponentImages(svc, servicePorts)...)
 	}
 
 	if err := writeZarfConfig(filepath.Join(root, "zarf.yaml"), app, secretVariables, dedupeStrings(images), hasSecrets); err != nil {
@@ -1095,6 +1090,17 @@ func buildDependencyInitContainers(svc model.Service, servicePorts map[string]in
 		})
 	}
 	return containers
+}
+
+func buildComponentImages(svc model.Service, servicePorts map[string]int) []string {
+	images := []string{}
+	if svc.Build == nil {
+		images = append(images, svc.Image)
+	}
+	if len(buildDependencyInitContainers(svc, servicePorts)) > 0 {
+		images = append(images, model.DependencyInitImage)
+	}
+	return dedupeStrings(images)
 }
 
 func buildEnv(env []model.EnvVar) []envVar {

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -23,6 +23,11 @@ const (
 	// root) referenced by the component's chart valuesFiles. Only written when
 	// the package has secrets.
 	zarfValuesRel = "values/values.yaml"
+	// buildComposeRel is the temporary Compose build definition consumed by
+	// Buildx Bake during Zarf package creation.
+	buildComposeRel     = "build.compose.yaml"
+	imageArchiveDir     = "image-archives"
+	buildxBuilderPrefix = "compose-bridge-uds"
 	// secretValuePlaceholder is the sentinel injected into a marshaled Secret's
 	// stringData and then replaced with a Helm value reference, so the Secret can
 	// be rendered by Helm from chart values rather than a static literal.
@@ -164,9 +169,20 @@ func WritePackage(root string, app model.App) error {
 		}
 	}
 
+	if hasBuildServices(app) {
+		if err := writeBuildCompose(filepath.Join(root, buildComposeRel), app); err != nil {
+			return err
+		}
+	}
+
 	images := make([]string, 0, len(app.Services))
 	for _, svc := range app.Services {
-		images = append(images, buildComponentImages(svc, servicePorts)...)
+		if svc.Build == nil {
+			images = append(images, svc.Image)
+		}
+		if len(buildDependencyInitContainers(svc, servicePorts)) > 0 {
+			images = append(images, model.DependencyInitImage)
+		}
 	}
 
 	if err := writeZarfConfig(filepath.Join(root, "zarf.yaml"), app, secretVariables, dedupeStrings(images), hasSecrets); err != nil {
@@ -174,6 +190,143 @@ func WritePackage(root string, app model.App) error {
 	}
 
 	return nil
+}
+
+// Compose build workspace and Zarf package-creation actions.
+
+func hasBuildServices(app model.App) bool {
+	for _, svc := range app.Services {
+		if svc.Build != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func writeBuildCompose(path string, app model.App) error {
+	services := map[string]buildComposeService{}
+	for _, svc := range app.Services {
+		if svc.Build == nil {
+			continue
+		}
+		services[svc.Name] = buildComposeService{
+			Image: svc.Image,
+			Build: svc.Build.Config,
+		}
+	}
+	return writeYAMLFile(path, buildComposeFile{
+		Name:     app.Package.Name,
+		Services: services,
+		Secrets:  app.BuildSecrets,
+	})
+}
+
+func buildCreateActions(app model.App) *zarfComponentActions {
+	if !hasBuildServices(app) {
+		return nil
+	}
+	builderVariables := []string{
+		`docker_context="$(docker context show)"`,
+		`builder_context="$(printf '%s' "$docker_context" | tr -c '[:alnum:]_.-' '-')"`,
+		fmt.Sprintf(`builder_name=%s"$builder_context"`, shellQuote(buildxBuilderPrefix+"-")),
+	}
+	ensureBuilderLines := []string{
+		"set -eu",
+	}
+	ensureBuilderLines = append(ensureBuilderLines, builderVariables...)
+	ensureBuilderLines = append(ensureBuilderLines,
+		`if ! docker buildx inspect "$builder_name" >/dev/null 2>&1; then`,
+		`  docker buildx create --name "$builder_name" --driver docker-container "$docker_context"`,
+		"fi",
+	)
+	ensureBuilder := strings.Join(ensureBuilderLines, "\n")
+
+	archives := []string{}
+	arguments := []string{
+		"docker buildx bake",
+		`  --builder "$builder_name"`,
+		"  --file " + shellQuote(buildComposeRel),
+		"  --progress plain",
+	}
+	readPaths := map[string]struct{}{}
+	for _, svc := range app.Services {
+		if svc.Build == nil {
+			continue
+		}
+		for _, path := range svc.Build.ReadPaths {
+			readPaths[path] = struct{}{}
+		}
+	}
+	for _, path := range sortedStringSet(readPaths) {
+		arguments = append(arguments, "  --allow "+shellQuote("fs.read="+path))
+	}
+	targets := []string{}
+	for _, svc := range app.Services {
+		if svc.Build == nil {
+			continue
+		}
+		target := svc.Name
+		archive := filepath.ToSlash(filepath.Join(imageArchiveDir, svc.Name+".tar"))
+		archives = append(archives, shellQuote(archive))
+		if !buildDeclaresPlatforms(svc.Build.Config) {
+			arguments = append(arguments,
+				"  --set "+shellQuote(target+".platform+=linux/amd64"),
+				"  --set "+shellQuote(target+".platform+=linux/arm64"),
+			)
+		}
+		arguments = append(arguments, "  --set "+shellQuote(target+".output=type=oci,dest="+archive))
+		targets = append(targets, shellQuote(target))
+	}
+	arguments = append(arguments, "  "+strings.Join(targets, " "))
+	for i := 0; i < len(arguments)-1; i++ {
+		arguments[i] += " \\"
+	}
+
+	buildImageLines := []string{
+		"set -eu",
+	}
+	buildImageLines = append(buildImageLines, builderVariables...)
+	buildImageLines = append(buildImageLines,
+		"mkdir -p "+shellQuote(imageArchiveDir),
+		"rm -f "+strings.Join(archives, " "),
+		strings.Join(arguments, "\n"),
+	)
+	buildImages := strings.Join(buildImageLines, "\n")
+
+	return &zarfComponentActions{OnCreate: zarfComponentActionSet{Before: []zarfComponentAction{
+		{Description: "Ensure the Compose Bridge Buildx builder exists", Cmd: ensureBuilder},
+		{Description: "Build Compose images for the package", Cmd: buildImages},
+	}}}
+}
+
+func buildDeclaresPlatforms(config map[string]any) bool {
+	value, ok := config["platforms"]
+	if !ok || value == nil {
+		return false
+	}
+	switch platforms := value.(type) {
+	case []any:
+		return len(platforms) > 0
+	case []string:
+		return len(platforms) > 0
+	case string:
+		return strings.TrimSpace(platforms) != ""
+	default:
+		return true
+	}
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func sortedStringSet(values map[string]struct{}) []string {
+	result := make([]string, 0, len(values))
+	for value := range values {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
 }
 
 // writeSecretTemplate writes a Helm-templated Secret whose value is sourced from
@@ -259,13 +412,24 @@ func writeZarfConfig(path string, app model.App, secretVariables map[string]stri
 	if hasSecrets {
 		chart.ValuesFiles = []string{zarfValuesRel}
 	}
-	pkg.Components = append(pkg.Components, zarfComponent{
+	component := zarfComponent{
 		Name:        app.Package.Name,
 		Required:    true,
 		Description: fmt.Sprintf("Deploy %s", app.Package.Name),
 		Charts:      []zarfChart{chart},
 		Images:      dedupeStrings(images),
-	})
+		Actions:     buildCreateActions(app),
+	}
+	for _, svc := range app.Services {
+		if svc.Build == nil {
+			continue
+		}
+		component.ImageArchives = append(component.ImageArchives, zarfImageArchive{
+			Path:   filepath.ToSlash(filepath.Join(imageArchiveDir, svc.Name+".tar")),
+			Images: []string{svc.Image},
+		})
+	}
+	pkg.Components = append(pkg.Components, component)
 
 	data, err := yamlv3.Marshal(pkg)
 	if err != nil {
@@ -298,6 +462,9 @@ func buildDeployment(appName string, namespace string, svc model.Service, servic
 		LivenessProbe:   buildProbe(svc.Healthcheck),
 		Resources:       resources,
 		SecurityContext: securityContext,
+	}
+	if svc.Build != nil {
+		container.ImagePullPolicy = "Always"
 	}
 
 	podLabels := serviceSelector(svc.Name)
@@ -930,14 +1097,6 @@ func buildDependencyInitContainers(svc model.Service, servicePorts map[string]in
 	return containers
 }
 
-func buildComponentImages(svc model.Service, servicePorts map[string]int) []string {
-	images := []string{svc.Image}
-	if len(buildDependencyInitContainers(svc, servicePorts)) > 0 {
-		images = append(images, model.DependencyInitImage)
-	}
-	return dedupeStrings(images)
-}
-
 func buildEnv(env []model.EnvVar) []envVar {
 	if len(env) == 0 {
 		return nil
@@ -1566,11 +1725,31 @@ type zarfVariable struct {
 }
 
 type zarfComponent struct {
-	Name        string      `yaml:"name"`
-	Required    bool        `yaml:"required"`
-	Description string      `yaml:"description,omitempty"`
-	Charts      []zarfChart `yaml:"charts,omitempty"`
-	Images      []string    `yaml:"images,omitempty"`
+	Name          string                `yaml:"name"`
+	Required      bool                  `yaml:"required"`
+	Description   string                `yaml:"description,omitempty"`
+	Charts        []zarfChart           `yaml:"charts,omitempty"`
+	Images        []string              `yaml:"images,omitempty"`
+	ImageArchives []zarfImageArchive    `yaml:"imageArchives,omitempty"`
+	Actions       *zarfComponentActions `yaml:"actions,omitempty"`
+}
+
+type zarfImageArchive struct {
+	Path   string   `yaml:"path"`
+	Images []string `yaml:"images"`
+}
+
+type zarfComponentActions struct {
+	OnCreate zarfComponentActionSet `yaml:"onCreate"`
+}
+
+type zarfComponentActionSet struct {
+	Before []zarfComponentAction `yaml:"before"`
+}
+
+type zarfComponentAction struct {
+	Description string `yaml:"description,omitempty"`
+	Cmd         string `yaml:"cmd"`
 }
 
 type zarfChart struct {
@@ -1579,6 +1758,17 @@ type zarfChart struct {
 	LocalPath   string   `yaml:"localPath"`
 	Version     string   `yaml:"version"`
 	ValuesFiles []string `yaml:"valuesFiles,omitempty"`
+}
+
+type buildComposeFile struct {
+	Name     string                         `yaml:"name"`
+	Services map[string]buildComposeService `yaml:"services"`
+	Secrets  map[string]any                 `yaml:"secrets,omitempty"`
+}
+
+type buildComposeService struct {
+	Image string         `yaml:"image"`
+	Build map[string]any `yaml:"build"`
 }
 
 // chartMetadata is the Chart.yaml written for the generated Helm chart.

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -23,11 +23,11 @@ const (
 	// root) referenced by the component's chart valuesFiles. Only written when
 	// the package has secrets.
 	zarfValuesRel = "values/values.yaml"
-	// buildComposeRel is the temporary Compose build definition consumed by
+	// buildComposeFileName is the generated Compose build definition consumed by
 	// Buildx Bake during Zarf package creation.
-	buildComposeRel     = "build.compose.yaml"
-	imageArchiveDir     = "image-archives"
-	buildxBuilderPrefix = "compose-bridge-uds"
+	buildComposeFileName = "build.compose.yaml"
+	imageArchiveDir      = "image-archives"
+	buildxBuilderPrefix  = "compose-bridge-uds"
 	// secretValuePlaceholder is the sentinel injected into a marshaled Secret's
 	// stringData and then replaced with a Helm value reference, so the Secret can
 	// be rendered by Helm from chart values rather than a static literal.
@@ -170,7 +170,7 @@ func WritePackage(root string, app model.App) error {
 	}
 
 	if hasBuildServices(app) {
-		if err := writeBuildCompose(filepath.Join(root, buildComposeRel), app); err != nil {
+		if err := writeBuildCompose(filepath.Join(root, buildComposeFileName), app); err != nil {
 			return err
 		}
 	}
@@ -245,7 +245,7 @@ func buildCreateActions(app model.App) *zarfComponentActions {
 	arguments := []string{
 		"docker buildx bake",
 		`  --builder "$builder_name"`,
-		"  --file " + shellQuote(buildComposeRel),
+		"  --file " + shellQuote(buildComposeFileName),
 		"  --progress plain",
 	}
 	readPaths := map[string]struct{}{}

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -13,7 +13,7 @@ import (
 	yamlv3 "gopkg.in/yaml.v3"
 )
 
-func TestLoadCanonicalAcceptsExplicitLocalBuildImage(t *testing.T) {
+func TestLoadCanonicalInternalizesBuildImage(t *testing.T) {
 	t.Parallel()
 
 	input := []byte(`name: demo
@@ -32,11 +32,17 @@ services:
 	if len(app.Services) != 1 {
 		t.Fatalf("expected 1 service, got %d", len(app.Services))
 	}
-	if app.Services[0].Image != "keel.local/api:latest" {
-		t.Fatalf("expected local image reference to be preserved, got %q", app.Services[0].Image)
+	if app.Services[0].Image != "zarf.internal/demo-api:0.1.0" {
+		t.Fatalf("expected build image reference to be internalized, got %q", app.Services[0].Image)
 	}
-	if !app.Services[0].UsesBuild {
+	if app.Services[0].Build == nil {
 		t.Fatalf("expected service to retain build metadata")
+	}
+	if app.Services[0].Build.Config["context"] != "/workspace" {
+		t.Fatalf("expected canonical build context, got %#v", app.Services[0].Build.Config)
+	}
+	if got := app.Services[0].Build.ReadPaths; len(got) != 1 || got[0] != "/workspace" {
+		t.Fatalf("expected exact local build read path, got %#v", got)
 	}
 }
 
@@ -130,7 +136,7 @@ services:
 	}
 }
 
-func TestLoadCanonicalRejectsBuildWithoutExplicitImage(t *testing.T) {
+func TestLoadCanonicalAcceptsBuildWithoutExplicitImage(t *testing.T) {
 	t.Parallel()
 
 	input := []byte(`name: demo
@@ -141,12 +147,243 @@ services:
       dockerfile: Dockerfile
 `)
 
-	_, err := compose.LoadCanonicalYAML(input)
-	if err == nil {
-		t.Fatalf("expected build without image to fail")
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("expected build without image to be supported, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "[build-image-unresolved]") {
-		t.Fatalf("expected build image validation error, got %v", err)
+	if got := app.Services[0].Image; got != "zarf.internal/demo-api:0.1.0" {
+		t.Fatalf("expected generated internal image, got %q", got)
+	}
+}
+
+func TestWritePackageGeneratesBuildWorkspaceAndImageArchives(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:dev
+    build:
+      context: /workspace/api
+      dockerfile: Containerfile
+      args:
+        MODE: release
+      tags:
+        - ghcr.io/acme/extra:dev
+      additional_contexts:
+        base: service:base_image
+      secrets:
+        - build_token
+  base_image:
+    build:
+      context: /workspace/base
+      platforms:
+        - linux/arm64
+  cache:
+    image: redis:7.4-alpine
+secrets:
+  build_token:
+    file: /workspace/build-token.txt
+x-uds:
+  package:
+    version: 1.2.3
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	buildCompose := readYAMLMap(t, filepath.Join(outDir, "build.compose.yaml"))
+	services := mustMap(t, buildCompose["services"])
+	api := mustMap(t, services["api"])
+	if got := api["image"]; got != "zarf.internal/demo-api:1.2.3" {
+		t.Fatalf("expected internal API image, got %#v", got)
+	}
+	apiBuild := mustMap(t, api["build"])
+	if got := apiBuild["context"]; got != "/workspace/api" {
+		t.Fatalf("expected canonical context, got %#v", got)
+	}
+	if _, exists := apiBuild["tags"]; exists {
+		t.Fatalf("did not expect user-controlled build tags in generated build file: %#v", apiBuild)
+	}
+	contexts := mustMap(t, apiBuild["additional_contexts"])
+	if got := contexts["base"]; got != "service:base-image" {
+		t.Fatalf("expected normalized service build context, got %#v", got)
+	}
+	if _, exists := mustMap(t, buildCompose["secrets"])["build_token"]; !exists {
+		t.Fatalf("expected referenced build secret in generated build file")
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "chart", "templates", "secret-build-token.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("did not expect build-only secret to generate a Kubernetes Secret")
+	}
+
+	zarfConfig := readFile(t, filepath.Join(outDir, "zarf.yaml"))
+	for _, want := range []string{
+		"imageArchives:",
+		"path: image-archives/api.tar",
+		"zarf.internal/demo-api:1.2.3",
+		"path: image-archives/base-image.tar",
+		"zarf.internal/demo-base-image:1.2.3",
+		"redis:7.4-alpine",
+		"docker buildx bake",
+		"fs.read=/workspace",
+		"fs.read=/workspace/api",
+		"fs.read=/workspace/base",
+		"api.platform+=linux/amd64",
+		"api.platform+=linux/arm64",
+		"api.output=type=oci,dest=image-archives/api.tar",
+		"base-image.output=type=oci,dest=image-archives/base-image.tar",
+	} {
+		if !strings.Contains(zarfConfig, want) {
+			t.Fatalf("expected zarf.yaml to contain %q\n%s", want, zarfConfig)
+		}
+	}
+	if strings.Contains(zarfConfig, "base-image.platform+=") {
+		t.Fatalf("did not expect default platforms to override declared build platforms\n%s", zarfConfig)
+	}
+	if strings.Contains(zarfConfig, "BUILD_TOKEN") {
+		t.Fatalf("did not expect build-only secret to generate a deploy-time variable\n%s", zarfConfig)
+	}
+	for _, want := range []string{
+		`docker_context="$(docker context show)"`,
+		`builder_name='compose-bridge-uds-'"$builder_context"`,
+		`docker buildx create --name "$builder_name" --driver docker-container "$docker_context"`,
+		`--builder "$builder_name"`,
+	} {
+		if !strings.Contains(zarfConfig, want) {
+			t.Fatalf("expected context-scoped Buildx builder command %q\n%s", want, zarfConfig)
+		}
+	}
+
+	deployment := readFile(t, filepath.Join(outDir, "chart", "templates", "deployment-api.yaml"))
+	if !strings.Contains(deployment, "imagePullPolicy: Always") {
+		t.Fatalf("expected built image to always pull from the Zarf registry\n%s", deployment)
+	}
+}
+
+func TestWritePackageKeepsSharedBuildSecretAtRuntime(t *testing.T) {
+	t.Parallel()
+
+	app, err := compose.LoadCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    build:
+      context: /workspace/api
+      secrets:
+        - shared_token
+    secrets:
+      - shared_token
+secrets:
+  shared_token:
+    file: /workspace/shared-token.txt
+`))
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	buildCompose := readYAMLMap(t, filepath.Join(outDir, "build.compose.yaml"))
+	if _, exists := mustMap(t, buildCompose["secrets"])["shared_token"]; !exists {
+		t.Fatalf("expected shared secret in generated build file")
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "chart", "templates", "secret-shared-token.yaml")); err != nil {
+		t.Fatalf("expected shared secret to generate a Kubernetes Secret: %v", err)
+	}
+	zarfConfig := readFile(t, filepath.Join(outDir, "zarf.yaml"))
+	if !strings.Contains(zarfConfig, "SHARED_TOKEN") {
+		t.Fatalf("expected shared secret to generate a deploy-time variable\n%s", zarfConfig)
+	}
+}
+
+func TestWritePackageWithoutBuildOmitsBuildWorkspace(t *testing.T) {
+	t.Parallel()
+
+	app, err := compose.LoadCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+`))
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "build.compose.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("did not expect build.compose.yaml without build services")
+	}
+	zarfConfig := readFile(t, filepath.Join(outDir, "zarf.yaml"))
+	for _, unexpected := range []string{"imageArchives:", "actions:", "docker buildx"} {
+		if strings.Contains(zarfConfig, unexpected) {
+			t.Fatalf("did not expect %q without build services\n%s", unexpected, zarfConfig)
+		}
+	}
+}
+
+func TestWritePackageSeparatesBuildServicesFromImageServices(t *testing.T) {
+	t.Parallel()
+
+	app, err := compose.LoadCanonicalYAML([]byte(`name: demo
+services:
+  server:
+    build:
+      context: /workspace/server
+  cache:
+    image: redis:7-alpine
+`))
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	zarfConfig := readYAMLMap(t, filepath.Join(outDir, "zarf.yaml"))
+	components, ok := zarfConfig["components"].([]any)
+	if !ok || len(components) != 1 {
+		t.Fatalf("expected one Zarf component, got %#v", zarfConfig["components"])
+	}
+	component := mustMap(t, components[0])
+
+	images, ok := component["images"].([]any)
+	if !ok || len(images) != 1 || images[0] != "redis:7-alpine" {
+		t.Fatalf("expected only the prebuilt image under images, got %#v", component["images"])
+	}
+
+	archives, ok := component["imageArchives"].([]any)
+	if !ok || len(archives) != 1 {
+		t.Fatalf("expected one image archive, got %#v", component["imageArchives"])
+	}
+	archive := mustMap(t, archives[0])
+	if archive["path"] != "image-archives/server.tar" {
+		t.Fatalf("expected server image archive path, got %#v", archive["path"])
+	}
+	archiveImages, ok := archive["images"].([]any)
+	if !ok || len(archiveImages) != 1 || archiveImages[0] != "zarf.internal/demo-server:0.1.0" {
+		t.Fatalf("expected only the built image under imageArchives, got %#v", archive["images"])
+	}
+
+	buildCompose := readYAMLMap(t, filepath.Join(outDir, "build.compose.yaml"))
+	buildServices := mustMap(t, buildCompose["services"])
+	if len(buildServices) != 1 {
+		t.Fatalf("expected only one service in the build workspace, got %#v", buildServices)
+	}
+	if _, ok := buildServices["server"]; !ok {
+		t.Fatalf("expected server in the build workspace, got %#v", buildServices)
+	}
+	if _, ok := buildServices["cache"]; ok {
+		t.Fatalf("did not expect the prebuilt cache service in the build workspace")
 	}
 }
 

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -218,9 +218,6 @@ x-uds:
 	if _, exists := mustMap(t, buildCompose["secrets"])["build_token"]; !exists {
 		t.Fatalf("expected referenced build secret in generated build file")
 	}
-	if _, err := os.Stat(filepath.Join(outDir, "chart", "templates", "secret-build-token.yaml")); !os.IsNotExist(err) {
-		t.Fatalf("did not expect build-only secret to generate a Kubernetes Secret")
-	}
 
 	zarfConfig := readFile(t, filepath.Join(outDir, "zarf.yaml"))
 	for _, want := range []string{
@@ -246,9 +243,6 @@ x-uds:
 	if strings.Contains(zarfConfig, "base-image.platform+=") {
 		t.Fatalf("did not expect default platforms to override declared build platforms\n%s", zarfConfig)
 	}
-	if strings.Contains(zarfConfig, "BUILD_TOKEN") {
-		t.Fatalf("did not expect build-only secret to generate a deploy-time variable\n%s", zarfConfig)
-	}
 	for _, want := range []string{
 		`docker_context="$(docker context show)"`,
 		`builder_name='compose-bridge-uds-'"$builder_context"`,
@@ -263,43 +257,6 @@ x-uds:
 	deployment := readFile(t, filepath.Join(outDir, "chart", "templates", "deployment-api.yaml"))
 	if !strings.Contains(deployment, "imagePullPolicy: Always") {
 		t.Fatalf("expected built image to always pull from the Zarf registry\n%s", deployment)
-	}
-}
-
-func TestWritePackageKeepsSharedBuildSecretAtRuntime(t *testing.T) {
-	t.Parallel()
-
-	app, err := compose.LoadCanonicalYAML([]byte(`name: demo
-services:
-  api:
-    build:
-      context: /workspace/api
-      secrets:
-        - shared_token
-    secrets:
-      - shared_token
-secrets:
-  shared_token:
-    file: /workspace/shared-token.txt
-`))
-	if err != nil {
-		t.Fatalf("LoadCanonicalYAML() error = %v", err)
-	}
-	outDir := t.TempDir()
-	if err := render.WritePackage(outDir, app); err != nil {
-		t.Fatalf("WritePackage() error = %v", err)
-	}
-
-	buildCompose := readYAMLMap(t, filepath.Join(outDir, "build.compose.yaml"))
-	if _, exists := mustMap(t, buildCompose["secrets"])["shared_token"]; !exists {
-		t.Fatalf("expected shared secret in generated build file")
-	}
-	if _, err := os.Stat(filepath.Join(outDir, "chart", "templates", "secret-shared-token.yaml")); err != nil {
-		t.Fatalf("expected shared secret to generate a Kubernetes Secret: %v", err)
-	}
-	zarfConfig := readFile(t, filepath.Join(outDir, "zarf.yaml"))
-	if !strings.Contains(zarfConfig, "SHARED_TOKEN") {
-		t.Fatalf("expected shared secret to generate a deploy-time variable\n%s", zarfConfig)
 	}
 }
 


### PR DESCRIPTION
As of [docker compose 5.5.0](https://github.com/docker/compose/releases/tag/v5.5.0) (PR https://github.com/docker/compose/pull/14010), docker compose bridge now supports running conversions for "Build-only" services (those that specify `build:` but do not specify `image:`)

This PR adds support for build-only services to compose-bridge-uds. These images are now built during zarf package create using generated Buildx Bake configuration and Zarf onCreate actions. The resulting OCI archives are included in the package through imageArchives.

Closes: #69 
