### PR TITLE
feat: generate protocol-neutral names for unnamed ports

### DIFF
--- a/docs/compose-support.md
+++ b/docs/compose-support.md
@@ -60,7 +60,7 @@ Deferred builds cannot automatically determine what to expose by examining the D
 - **Bind mounts:** Bind mounts are treated as local-development-only inputs and omitted from the rendered chart with a warning. Use a named volume when the data should become a PVC, or a config or secret when the mounted content should be materialized in Kubernetes.
 - **Network topology:** A shared Compose network maps to the package namespace. When services join different network sets, the bridge labels Pods by membership and allows communication only between services that share a network.
 - **External networks:** Membership among converted services is preserved, but external peers cannot be inferred from the transformation input. Conversion emits a warning; declare cross-package traffic explicitly with `x-uds.network.allow`.
-- **Generated port names:** Compose long-syntax `name` values are preserved after Kubernetes-compatible sanitization. Unnamed ports use the neutral `port-<number>-<protocol>` form; the bridge does not assume that the first TCP port carries HTTP traffic.
+- **Port names:** The bridge preserves explicit Compose port names after Kubernetes-compatible sanitization. For unnamed ports, it generates `port-<number>-<protocol>` (for example, port-5432-tcp) instead of assuming an HTTP port.
 - **Docker runtime settings:** Host networking, alternate runtimes and platforms, sysctls, Docker discovery labels, and custom stop signals are rejected when they cannot be represented faithfully.
 
 See the [full Compose example](../examples/full/compose.yaml) and [UDS package generation](uds-package.md) for extension keys and generated behavior.

--- a/docs/compose-support.md
+++ b/docs/compose-support.md
@@ -60,6 +60,7 @@ Deferred builds cannot automatically determine what to expose by examining the D
 - **Bind mounts:** Bind mounts are treated as local-development-only inputs and omitted from the rendered chart with a warning. Use a named volume when the data should become a PVC, or a config or secret when the mounted content should be materialized in Kubernetes.
 - **Network topology:** A shared Compose network maps to the package namespace. When services join different network sets, the bridge labels Pods by membership and allows communication only between services that share a network.
 - **External networks:** Membership among converted services is preserved, but external peers cannot be inferred from the transformation input. Conversion emits a warning; declare cross-package traffic explicitly with `x-uds.network.allow`.
+- **Generated port names:** Compose long-syntax `name` values are preserved after Kubernetes-compatible sanitization. Unnamed ports use the neutral `port-<number>-<protocol>` form; the bridge does not assume that the first TCP port carries HTTP traffic.
 - **Docker runtime settings:** Host networking, alternate runtimes and platforms, sysctls, Docker discovery labels, and custom stop signals are rejected when they cannot be represented faithfully.
 
 See the [full Compose example](../examples/full/compose.yaml) and [UDS package generation](uds-package.md) for extension keys and generated behavior.

--- a/docs/compose-support.md
+++ b/docs/compose-support.md
@@ -60,7 +60,7 @@ Deferred builds cannot automatically determine what to expose by examining the D
 - **Bind mounts:** Bind mounts are treated as local-development-only inputs and omitted from the rendered chart with a warning. Use a named volume when the data should become a PVC, or a config or secret when the mounted content should be materialized in Kubernetes.
 - **Network topology:** A shared Compose network maps to the package namespace. When services join different network sets, the bridge labels Pods by membership and allows communication only between services that share a network.
 - **External networks:** Membership among converted services is preserved, but external peers cannot be inferred from the transformation input. Conversion emits a warning; declare cross-package traffic explicitly with `x-uds.network.allow`.
-- **Port names:** The bridge preserves explicit Compose port names after Kubernetes-compatible sanitization. For unnamed ports, it generates `port-<number>-<protocol>` (for example, port-5432-tcp) instead of assuming an HTTP port.
+- **Port names:** The bridge preserves explicit Compose port names after Kubernetes-compatible sanitization. For unnamed ports, it generates `port-<number>-<protocol>` (for example, port-5432-tcp) instead of assuming an HTTP port. Conversion fails when two ports in the same service resolve to the same Kubernetes port name.
 - **Docker runtime settings:** Host networking, alternate runtimes and platforms, sysctls, Docker discovery labels, and custom stop signals are rejected when they cannot be represented faithfully.
 
 See the [full Compose example](../examples/full/compose.yaml) and [UDS package generation](uds-package.md) for extension keys and generated behavior.

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -832,12 +832,12 @@ type monitorPort struct {
 
 func monitorPortsForService(svc model.Service) []monitorPort {
 	ports := make([]monitorPort, 0, len(svc.Ports))
-	for i, port := range svc.Ports {
+	for _, port := range svc.Ports {
 		if !strings.EqualFold(port.Protocol, "TCP") {
 			continue
 		}
 		ports = append(ports, monitorPort{
-			Name:   buildPortName(i, port),
+			Name:   buildPortName(port),
 			Number: port.Number,
 		})
 	}
@@ -1119,9 +1119,9 @@ func buildContainerPorts(ports []model.Port) []containerPort {
 		return nil
 	}
 	out := make([]containerPort, 0, len(ports))
-	for i, port := range ports {
+	for _, port := range ports {
 		out = append(out, containerPort{
-			Name:          buildPortName(i, port),
+			Name:          buildPortName(port),
 			ContainerPort: port.Number,
 			Protocol:      strings.ToUpper(port.Protocol),
 		})
@@ -1131,9 +1131,9 @@ func buildContainerPorts(ports []model.Port) []containerPort {
 
 func buildServicePorts(ports []model.Port) []servicePort {
 	out := make([]servicePort, 0, len(ports))
-	for i, port := range ports {
+	for _, port := range ports {
 		out = append(out, servicePort{
-			Name:        buildPortName(i, port),
+			Name:        buildPortName(port),
 			Port:        port.Number,
 			Protocol:    strings.ToUpper(port.Protocol),
 			TargetPort:  port.Number,
@@ -1347,12 +1347,9 @@ func buildSecretVariableName(secretName string, used map[string]struct{}) string
 	}
 }
 
-func buildPortName(index int, port model.Port) string {
+func buildPortName(port model.Port) string {
 	if name := sanitizePortName(port.Name); name != "" {
 		return name
-	}
-	if index == 0 && strings.EqualFold(port.Protocol, "TCP") {
-		return "http"
 	}
 	return fmt.Sprintf("port-%d-%s", port.Number, strings.ToLower(port.Protocol))
 }

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -36,6 +36,10 @@ const (
 )
 
 func WritePackage(root string, app model.App) error {
+	if err := validatePortNames(app.Services); err != nil {
+		return err
+	}
+
 	chartDir := filepath.Join(root, chartDirName)
 	templatesDir := filepath.Join(chartDir, "templates")
 	for _, dir := range []string{root, chartDir, templatesDir} {
@@ -1352,6 +1356,34 @@ func buildPortName(port model.Port) string {
 		return name
 	}
 	return fmt.Sprintf("port-%d-%s", port.Number, strings.ToLower(port.Protocol))
+}
+
+func validatePortNames(services []model.Service) error {
+	for _, svc := range services {
+		seen := make(map[string]model.Port, len(svc.Ports))
+		for _, port := range svc.Ports {
+			name := buildPortName(port)
+			if previous, exists := seen[name]; exists {
+				return fmt.Errorf(
+					"service %q ports %s and %s resolve to duplicate Kubernetes port name %q",
+					svc.Name,
+					formatPortNameSource(previous),
+					formatPortNameSource(port),
+					name,
+				)
+			}
+			seen[name] = port
+		}
+	}
+	return nil
+}
+
+func formatPortNameSource(port model.Port) string {
+	source := "unnamed"
+	if name := strings.TrimSpace(port.Name); name != "" {
+		source = fmt.Sprintf("name %q", name)
+	}
+	return fmt.Sprintf("%d/%s (%s)", port.Number, strings.ToLower(port.Protocol), source)
 }
 
 func sanitizePortName(raw string) string {

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -1060,8 +1060,149 @@ services:
 	if !strings.Contains(service, "name: port-5432-tcp") {
 		t.Fatalf("expected neutral service port name\n%s", service)
 	}
-	if strings.Contains(service, "name: http") {
-		t.Fatalf("did not expect an unnamed TCP port to be labeled HTTP\n%s", service)
+}
+
+func TestWritePackageRejectsDuplicateResolvedPortNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		ports        string
+		resolvedName string
+		firstPort    string
+		secondPort   string
+	}{
+		{
+			name: "generated and explicit",
+			ports: `
+      - name: port-9090-tcp
+        target: 8080
+        published: "8080"
+        protocol: tcp
+      - target: 9090
+        published: "9090"
+        protocol: tcp`,
+			resolvedName: "port-9090-tcp",
+			firstPort:    `8080/tcp (name "port-9090-tcp")`,
+			secondPort:   "9090/tcp (unnamed)",
+		},
+		{
+			name: "sanitized explicit names",
+			ports: `
+      - name: WEB__UI
+        target: 8080
+        published: "8080"
+        protocol: tcp
+      - name: web-ui
+        target: 9090
+        published: "9090"
+        protocol: tcp`,
+			resolvedName: "web-ui",
+			firstPort:    `8080/tcp (name "WEB__UI")`,
+			secondPort:   `9090/tcp (name "web-ui")`,
+		},
+		{
+			name: "truncated explicit names",
+			ports: `
+      - name: abcdefghijklmno-one
+        target: 8080
+        published: "8080"
+        protocol: tcp
+      - name: abcdefghijklmno-two
+        target: 9090
+        published: "9090"
+        protocol: tcp`,
+			resolvedName: "abcdefghijklmno",
+			firstPort:    `8080/tcp (name "abcdefghijklmno-one")`,
+			secondPort:   `9090/tcp (name "abcdefghijklmno-two")`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			input := []byte(`name: collision-demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    ports:` + tt.ports + "\n")
+			app, err := compose.LoadCanonicalYAML(input)
+			if err != nil {
+				t.Fatalf("LoadCanonicalYAML() error = %v", err)
+			}
+
+			outDir := filepath.Join(t.TempDir(), "out")
+			err = render.WritePackage(outDir, app)
+			if err == nil {
+				t.Fatal("expected WritePackage() to reject duplicate resolved port names")
+			}
+			for _, want := range []string{`service "api"`, tt.resolvedName, tt.firstPort, tt.secondPort} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("expected error to contain %q, got %v", want, err)
+				}
+			}
+			if _, statErr := os.Stat(outDir); !os.IsNotExist(statErr) {
+				t.Fatalf("expected validation before output creation, os.Stat() error = %v", statErr)
+			}
+		})
+	}
+}
+
+func TestWritePackageScopesPortNamesToService(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: shared-port-name-demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    expose:
+      - "8080"
+  admin:
+    image: ghcr.io/acme/admin:1.0.0
+    expose:
+      - "8080"
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	if err := render.WritePackage(t.TempDir(), app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+}
+
+func TestWritePackageAllowsSamePortNumberWithDifferentProtocols(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: protocol-port-name-demo
+services:
+  dns:
+    image: ghcr.io/acme/dns:1.0.0
+    ports:
+      - target: 53
+        published: "53"
+        protocol: tcp
+      - target: 53
+        published: "53"
+        protocol: udp
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	service := readFile(t, filepath.Join(outDir, "chart", "templates", "service-dns.yaml"))
+	for _, want := range []string{"name: port-53-tcp", "name: port-53-udp"} {
+		if !strings.Contains(service, want) {
+			t.Fatalf("expected service to contain %q\n%s", want, service)
+		}
 	}
 }
 

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -990,6 +990,10 @@ func TestWritePackageSanitizesComposePortNames(t *testing.T) {
 	t.Parallel()
 
 	input := []byte(`name: port-name-demo
+x-uds:
+  monitor:
+    - service: web
+      targetPort: 8080
 services:
   web:
     image: ghcr.io/acme/web:1.0.0
@@ -1013,7 +1017,12 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
+	deployment := readFile(t, filepath.Join(outDir, "chart", "templates", "deployment-web.yaml"))
 	service := readFile(t, filepath.Join(outDir, "chart", "templates", "service-web.yaml"))
+	udsPackage := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
+	if !strings.Contains(deployment, "name: web-ui") {
+		t.Fatalf("expected deployment port name to preserve the sanitized Compose name\n%s", deployment)
+	}
 	for _, want := range []string{
 		"name: web-ui",
 		"name: port-9090-tcp",
@@ -1021,6 +1030,38 @@ services:
 		if !strings.Contains(service, want) {
 			t.Fatalf("expected service port name %q\n%s", want, service)
 		}
+	}
+	if !strings.Contains(udsPackage, "portName: web-ui") {
+		t.Fatalf("expected monitor port name to preserve the sanitized Compose name\n%s", udsPackage)
+	}
+}
+
+func TestWritePackageUsesNeutralUnnamedPortNames(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: unnamed-port-demo
+services:
+  db:
+    image: postgres:18.4-bookworm
+    expose:
+      - "5432"
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	service := readFile(t, filepath.Join(outDir, "chart", "templates", "service-db.yaml"))
+	if !strings.Contains(service, "name: port-5432-tcp") {
+		t.Fatalf("expected neutral service port name\n%s", service)
+	}
+	if strings.Contains(service, "name: http") {
+		t.Fatalf("did not expect an unnamed TCP port to be labeled HTTP\n%s", service)
 	}
 }
 
@@ -1243,7 +1284,7 @@ services:
 		"selector:",
 		"podSelector:",
 		"app.kubernetes.io/name: api",
-		"portName: http",
+		"portName: port-9090-tcp",
 		"targetPort: 9090",
 		"path: /metrics",
 		"kind: ServiceMonitor",
@@ -1291,7 +1332,7 @@ services:
 	for _, want := range []string{
 		"kind: PodMonitor",
 		"path: /custom/metrics",
-		"portName: http",
+		"portName: port-9090-tcp",
 		"targetPort: 9090",
 		"authorization:",
 		"type: Bearer",
@@ -1451,7 +1492,7 @@ func TestMonitorRejectsMismatchedPortNameAndTargetPort(t *testing.T) {
 x-uds:
   monitor:
     - service: api
-      portName: http
+      portName: port-8080-tcp
       targetPort: 9090
 services:
   api:
@@ -1470,7 +1511,7 @@ services:
 	if err == nil {
 		t.Fatalf("expected WritePackage() to fail for mismatched monitor port fields")
 	}
-	if !strings.Contains(err.Error(), `portName "http" resolves to 8080, but targetPort is 9090`) {
+	if !strings.Contains(err.Error(), `portName "port-8080-tcp" resolves to 8080, but targetPort is 9090`) {
 		t.Fatalf("expected mismatched port error, got %v", err)
 	}
 }


### PR DESCRIPTION
Generate port names in the format `port-<number>-<protocol>` when a name isn't specified.