### PR TITLE
feat(config): externalize service environment variables through reloadable ConfigMaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ zarf package create out/
 zarf package deploy zarf-package-wordpress-*.tar.zst
 ```
 
-The transformation writes a Helm chart to `out/chart/`, a Zarf package definition to `out/zarf.yaml`, and `out/values/` when the Compose file declares secrets. Services with `build:` are built during `zarf package create` through a generated Buildx Bake definition. See [Compose support](docs/compose-support.md#local-dockerfile-builds) for Docker Compose version-specific conversion steps.
+The transformation writes a Helm chart to `out/chart/`, a Zarf package definition to `out/zarf.yaml`, and `out/values/` when the Compose file declares secrets or service environment variables. Services with `build:` are built during `zarf package create` through a generated Buildx Bake definition. See [Compose support](docs/compose-support.md#local-dockerfile-builds) for Docker Compose version-specific conversion steps.
 
 ## Documentation
 

--- a/docs/compose-support.md
+++ b/docs/compose-support.md
@@ -8,8 +8,8 @@
 | `build:`                                                         | Preserved as a generated Buildx Bake definition. `zarf package create` builds the image and adds its OCI archive to the package.                                                                                                                                                |
 | Named `volumes:`                                                 | Converted to PersistentVolumeClaims (`1Gi`, `ReadWriteOnce` by default).                                                                                                                                                                                                        |
 | `secrets:`                                                       | Converted to Kubernetes Secrets.                                                                                                                                                                                                                                                |
-| `configs:`                                                       | Converted to ConfigMaps. Must use inline `content:` (no external file references).                                                                                                                                                                                              |
-| `environment:`, `env_file:`                                      | Resolved by `docker compose config` and injected as container environment variables.                                                                                                                                                                                            |
+| `configs:`                                                       | Converted to reloadable ConfigMaps. Must use inline `content:` (no external file references).                                                                                                                                                                                   |
+| `environment:`, `env_file:`                                      | Resolved by `docker compose config`, exposed as non-sensitive Zarf variables, and rendered into a reloadable ConfigMap consumed by the service through `envFrom`.                                                                                                               |
 | `depends_on:`                                                    | Converted to init-container wait logic using `netcat` (busybox). The dependency must declare a port.                                                                                                                                                                            |
 | `healthcheck:`                                                   | `CMD` and `CMD-SHELL` forms convert to Kubernetes liveness probes.                                                                                                                                                                                                              |
 | `container_name:`                                                | Ignored with a warning. Kubernetes Service and Deployment names come from the Compose service name.                                                                                                                                                                             |
@@ -22,6 +22,14 @@
 | `user:`, `privileged:`, `cap_add:`, `cap_drop:`, `security_opt:` | Reflected in the container security context where applicable. Settings that require UDS policy exceptions also generate a `chart/templates/uds-exemption.yaml`.                                                                                                                 |
 
 External configs are not supported. A `configs:` entry must define inline `content:`.
+
+## Runtime configuration
+
+Every resolved service environment value becomes a non-sensitive Zarf variable named `<SERVICE>_<ENVIRONMENT_VARIABLE>`. The value resolved by `docker compose config`, including an empty value, is retained as its deployment default in `zarf.yaml`.
+
+The bridge renders one `<service>-environment` ConfigMap for each service with environment values and attaches it to that service through `envFrom`. Empty environment ConfigMaps are omitted. Environment and Compose configuration ConfigMaps carry the `uds.dev/pod-reload: "true"` label so UDS can restart dependent Pods when their data changes. Direct Helm deployments do not provide that UDS reload behavior.
+
+ConfigMaps do not protect sensitive data; use Compose `secrets:` for credentials and other confidential values. Environment names must use the portable `[A-Za-z_][A-Za-z0-9_]*` form. Generated Zarf variable names must also be unique across all services, secrets, and reserved package variables such as `ADDITIONAL_NETWORK_ALLOW`; conversion fails rather than emitting an ambiguous package when names collide.
 
 ## Local Dockerfile builds
 

--- a/docs/uds-package.md
+++ b/docs/uds-package.md
@@ -4,7 +4,7 @@ The bridge maps the [Compose Specification](https://compose-spec.io/) to Kuberne
 
 For services with `build:`, the bridge also writes `out/build.compose.yaml`. Zarf `onCreate` actions use Buildx Bake to build those services into OCI archives under `out/image-archives/`, and the component's `imageArchives` entries add them to the package.
 
-Secrets are rendered from chart values rather than baked into templates. The bridge writes `out/values/values.yaml` with `###ZARF_VAR_*###` placeholders, references it through `charts[].valuesFiles`, and retains the prompt and sensitivity settings in the Zarf package's `variables:`.
+Secrets are rendered from chart values rather than baked into templates. Service environment values are exposed as non-sensitive Zarf variables and rendered into per-service ConfigMaps. The bridge writes `out/values/values.yaml` with `###ZARF_VAR_*###` placeholders for both forms of deploy-time configuration, references it through `charts[].valuesFiles`, and retains their defaults, prompts, and sensitivity settings in the Zarf package's `variables:`.
 
 ## Inferred behavior
 

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -21,7 +21,7 @@ const (
 	chartDirName = "chart"
 	// zarfValuesRel is the Zarf-templated values file (relative to the package
 	// root) referenced by the component's chart valuesFiles. Only written when
-	// the package has secrets.
+	// the package has deploy-time values.
 	zarfValuesRel = "values/values.yaml"
 	// buildComposeFileName is the generated Compose build definition consumed by
 	// Buildx Bake during Zarf package creation.
@@ -33,9 +33,20 @@ const (
 	// be rendered by Helm from chart values rather than a static literal.
 	secretValuePlaceholder    = "__HELM_SECRET_VALUE__"
 	composeNetworkLabelPrefix = "network.compose.bridge.uds.dev/"
+	podReloadLabel            = "uds.dev/pod-reload"
+	// additionalNetworkAllowVariable is reserved for package-level deploy-time
+	// network configuration (see issue #73). Environment and secret variables
+	// must not claim the same Zarf variable name.
+	additionalNetworkAllowVariable = "ADDITIONAL_NETWORK_ALLOW"
 )
 
 func WritePackage(root string, app model.App) error {
+	secretVariables := buildSecretVariables(app.Secrets)
+	environmentVariables, err := buildEnvironmentVariables(app, secretVariables)
+	if err != nil {
+		return err
+	}
+
 	chartDir := filepath.Join(root, chartDirName)
 	templatesDir := filepath.Join(chartDir, "templates")
 	for _, dir := range []string{root, chartDir, templatesDir} {
@@ -44,7 +55,6 @@ func WritePackage(root string, app model.App) error {
 		}
 	}
 
-	secretVariables := buildSecretVariables(app.Secrets)
 	preserveNetworkMembership := hasDistinctNetworkMemberships(app.Services)
 	servicePorts := map[string]int{}
 	for _, svc := range app.Services {
@@ -99,10 +109,23 @@ func WritePackage(root string, app model.App) error {
 			Metadata: objectMeta{
 				Name:      config.Name,
 				Namespace: app.Package.Namespace,
-				Labels:    appLabels(app.Package.Name, config.Name),
+				Labels:    reloadableAppLabels(app.Package.Name, config.Name),
 			},
 			Data: map[string]string{config.Name: config.Content},
 		}); err != nil {
+			return err
+		}
+	}
+
+	for _, svc := range app.Services {
+		if len(svc.Env) == 0 {
+			continue
+		}
+		if err := writeEnvironmentConfigMapTemplate(
+			filepath.Join(templatesDir, fmt.Sprintf("configmap-%s-environment.yaml", svc.Name)),
+			app,
+			svc,
+		); err != nil {
 			return err
 		}
 	}
@@ -154,17 +177,17 @@ func WritePackage(root string, app model.App) error {
 	if err := writeChartMetadata(filepath.Join(chartDir, "Chart.yaml"), app); err != nil {
 		return err
 	}
-	if err := writeChartValues(filepath.Join(chartDir, "values.yaml"), secretValueKeys, false); err != nil {
+	if err := writeChartValues(filepath.Join(chartDir, "values.yaml"), app, secretValueKeys, environmentVariables, false); err != nil {
 		return err
 	}
 
-	hasSecrets := len(secretValueKeys) > 0
-	if hasSecrets {
+	hasDeployValues := len(secretValueKeys) > 0 || len(environmentVariables) > 0
+	if hasDeployValues {
 		valuesPath := filepath.Join(root, filepath.FromSlash(zarfValuesRel))
 		if err := os.MkdirAll(filepath.Dir(valuesPath), 0o755); err != nil {
 			return fmt.Errorf("create directory %s: %w", filepath.Dir(valuesPath), err)
 		}
-		if err := writeChartValues(valuesPath, secretValueKeys, true); err != nil {
+		if err := writeChartValues(valuesPath, app, secretValueKeys, environmentVariables, true); err != nil {
 			return err
 		}
 	}
@@ -180,7 +203,7 @@ func WritePackage(root string, app model.App) error {
 		images = append(images, buildComponentImages(svc, servicePorts)...)
 	}
 
-	if err := writeZarfConfig(filepath.Join(root, "zarf.yaml"), app, secretVariables, dedupeStrings(images), hasSecrets); err != nil {
+	if err := writeZarfConfig(filepath.Join(root, "zarf.yaml"), app, secretVariables, environmentVariables, dedupeStrings(images), hasDeployValues); err != nil {
 		return err
 	}
 
@@ -350,6 +373,46 @@ func writeSecretTemplate(path string, app model.App, secret model.Secret, variab
 	return nil
 }
 
+// writeEnvironmentConfigMapTemplate writes one observable configuration object
+// per service. Helm supplies each value, and the UDS pod-reload label causes the
+// consuming workload to roll when deploy-time configuration changes.
+func writeEnvironmentConfigMapTemplate(path string, app model.App, svc model.Service) error {
+	data := make(map[string]string, len(svc.Env))
+	placeholders := make(map[string]string, len(svc.Env))
+	for i, item := range svc.Env {
+		placeholder := fmt.Sprintf("__HELM_ENVIRONMENT_VALUE_%d__", i)
+		data[item.Name] = placeholder
+		placeholders[placeholder] = fmt.Sprintf(
+			"{{ index .Values.environment %q %q | quote }}",
+			svc.Name,
+			item.Name,
+		)
+	}
+
+	manifest := configMapManifest{
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+		Metadata: objectMeta{
+			Name:      environmentConfigMapName(svc.Name),
+			Namespace: app.Package.Namespace,
+			Labels:    reloadableAppLabels(app.Package.Name, svc.Name),
+		},
+		Data: data,
+	}
+	marshaled, err := yamlv3.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("marshal yaml for %s: %w", path, err)
+	}
+	rendered := string(marshaled)
+	for placeholder, helmValue := range placeholders {
+		rendered = strings.ReplaceAll(rendered, placeholder, helmValue)
+	}
+	if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil {
+		return fmt.Errorf("write file %s: %w", path, err)
+	}
+	return nil
+}
+
 // writeChartMetadata writes the generated chart's Chart.yaml.
 func writeChartMetadata(path string, app model.App) error {
 	return writeYAMLFile(path, chartMetadata{
@@ -362,9 +425,31 @@ func writeChartMetadata(path string, app model.App) error {
 	})
 }
 
-// writeChartValues writes a values document mapping each secret values key to a
-// default (empty) value, or to a Zarf variable placeholder when placeholder is set.
-func writeChartValues(path string, secretKeys []string, placeholder bool) error {
+// writeChartValues writes service environment and secret values either as chart
+// defaults or as Zarf variable placeholders.
+func writeChartValues(
+	path string,
+	app model.App,
+	secretKeys []string,
+	environmentVariables map[string]map[string]string,
+	placeholder bool,
+) error {
+	environment := map[string]map[string]string{}
+	for _, svc := range app.Services {
+		if len(svc.Env) == 0 {
+			continue
+		}
+		serviceValues := make(map[string]string, len(svc.Env))
+		for _, item := range svc.Env {
+			value := item.Value
+			if placeholder {
+				value = fmt.Sprintf("###ZARF_VAR_%s###", environmentVariables[svc.Name][item.Name])
+			}
+			serviceValues[item.Name] = value
+		}
+		environment[svc.Name] = serviceValues
+	}
+
 	secrets := map[string]string{}
 	for _, key := range secretKeys {
 		if placeholder {
@@ -373,10 +458,17 @@ func writeChartValues(path string, secretKeys []string, placeholder bool) error 
 			secrets[key] = ""
 		}
 	}
-	return writeYAMLFile(path, chartValues{Secrets: secrets})
+	return writeYAMLFile(path, chartValues{Environment: environment, Secrets: secrets})
 }
 
-func writeZarfConfig(path string, app model.App, secretVariables map[string]string, images []string, hasSecrets bool) error {
+func writeZarfConfig(
+	path string,
+	app model.App,
+	secretVariables map[string]string,
+	environmentVariables map[string]map[string]string,
+	images []string,
+	hasDeployValues bool,
+) error {
 	variables := []zarfVariable{}
 	for _, secretName := range sortedSecretNames(app.Secrets) {
 		variables = append(variables, zarfVariable{
@@ -385,6 +477,15 @@ func writeZarfConfig(path string, app model.App, secretVariables map[string]stri
 			Prompt:      true,
 			Sensitive:   true,
 		})
+	}
+	for _, svc := range app.Services {
+		for _, item := range svc.Env {
+			variables = append(variables, zarfVariable{
+				Name:        environmentVariables[svc.Name][item.Name],
+				Description: fmt.Sprintf("Value for %s environment variable on compose service %s", item.Name, svc.Name),
+				Default:     stringPointer(item.Value),
+			})
+		}
 	}
 
 	pkg := zarfPackageConfig{
@@ -404,7 +505,7 @@ func writeZarfConfig(path string, app model.App, secretVariables map[string]stri
 		LocalPath: chartDirName,
 		Version:   app.Package.Version,
 	}
-	if hasSecrets {
+	if hasDeployValues {
 		chart.ValuesFiles = []string{zarfValuesRel}
 	}
 	component := zarfComponent{
@@ -451,7 +552,7 @@ func buildDeployment(appName string, namespace string, svc model.Service, servic
 		Command:         svc.Command,
 		Args:            svc.Args,
 		Stdin:           svc.Stdin,
-		Env:             buildEnv(svc.Env),
+		EnvFrom:         buildEnvFrom(svc),
 		Ports:           buildContainerPorts(ports),
 		VolumeMounts:    volumeMounts,
 		LivenessProbe:   buildProbe(svc.Healthcheck),
@@ -1103,15 +1204,13 @@ func buildComponentImages(svc model.Service, servicePorts map[string]int) []stri
 	return dedupeStrings(images)
 }
 
-func buildEnv(env []model.EnvVar) []envVar {
-	if len(env) == 0 {
+func buildEnvFrom(svc model.Service) []envFromSource {
+	if len(svc.Env) == 0 {
 		return nil
 	}
-	out := make([]envVar, 0, len(env))
-	for _, item := range env {
-		out = append(out, envVar{Name: item.Name, Value: item.Value})
-	}
-	return out
+	return []envFromSource{{
+		ConfigMapRef: &configMapEnvSource{Name: environmentConfigMapName(svc.Name)},
+	}}
 }
 
 func buildContainerPorts(ports []model.Port) []containerPort {
@@ -1319,6 +1418,89 @@ func buildProbe(healthcheck *model.Healthcheck) *probe {
 	}
 }
 
+func buildEnvironmentVariables(
+	app model.App,
+	secretVariables map[string]string,
+) (map[string]map[string]string, error) {
+	usedVariables := map[string]string{
+		additionalNetworkAllowVariable: "reserved package variable",
+	}
+	for _, secretName := range sortedSecretNames(app.Secrets) {
+		if err := registerZarfVariable(
+			usedVariables,
+			secretVariables[secretName],
+			fmt.Sprintf("compose secret %q", secretName),
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	renderedConfigMaps := map[string]string{}
+	for _, configName := range sortedConfigNames(app.Configs) {
+		config := app.Configs[configName]
+		if !config.External {
+			renderedConfigMaps[config.Name] = configName
+		}
+	}
+
+	out := map[string]map[string]string{}
+	for _, svc := range app.Services {
+		if len(svc.Env) == 0 {
+			continue
+		}
+		configMapName := environmentConfigMapName(svc.Name)
+		if composeConfig, exists := renderedConfigMaps[configMapName]; exists {
+			return nil, fmt.Errorf(
+				"environment ConfigMap %q for service %q conflicts with compose config %q",
+				configMapName,
+				svc.Name,
+				composeConfig,
+			)
+		}
+
+		serviceVariables := map[string]string{}
+		for _, item := range svc.Env {
+			if !portableEnvironmentName.MatchString(item.Name) {
+				return nil, fmt.Errorf(
+					"invalid environment variable %q on service %q: names used with generated envFrom ConfigMaps must match %s",
+					item.Name,
+					svc.Name,
+					portableEnvironmentName.String(),
+				)
+			}
+			variableName := normalizeZarfVariableName(svc.Name + "_" + item.Name)
+			owner := fmt.Sprintf("environment variable %q on service %q", item.Name, svc.Name)
+			if err := registerZarfVariable(usedVariables, variableName, owner); err != nil {
+				return nil, err
+			}
+			serviceVariables[item.Name] = variableName
+		}
+		out[svc.Name] = serviceVariables
+	}
+	return out, nil
+}
+
+func registerZarfVariable(used map[string]string, name, owner string) error {
+	if !validZarfVariableName.MatchString(name) {
+		return fmt.Errorf(
+			"%s generates invalid Zarf variable %q: names must match %s",
+			owner,
+			name,
+			validZarfVariableName.String(),
+		)
+	}
+	if existing, exists := used[name]; exists {
+		return fmt.Errorf(
+			"%s generates Zarf variable %q, which conflicts with %s",
+			owner,
+			name,
+			existing,
+		)
+	}
+	used[name] = owner
+	return nil
+}
+
 func buildSecretVariables(secrets map[string]model.Secret) map[string]string {
 	used := map[string]struct{}{}
 	out := map[string]string{}
@@ -1329,14 +1511,7 @@ func buildSecretVariables(secrets map[string]model.Secret) map[string]string {
 }
 
 func buildSecretVariableName(secretName string, used map[string]struct{}) string {
-	base := strings.ToUpper(strings.TrimSpace(secretName))
-	base = strings.ReplaceAll(base, "-", "_")
-	base = strings.ReplaceAll(base, ".", "_")
-	base = invalidSecretVariableRunes.ReplaceAllString(base, "_")
-	base = strings.Trim(base, "_")
-	if base == "" {
-		base = "VALUE"
-	}
+	base := normalizeZarfVariableName(secretName)
 	candidate := base
 	for i := 2; ; i++ {
 		if _, exists := used[candidate]; !exists {
@@ -1345,6 +1520,22 @@ func buildSecretVariableName(secretName string, used map[string]struct{}) string
 		}
 		candidate = fmt.Sprintf("%s_%d", base, i)
 	}
+}
+
+func normalizeZarfVariableName(raw string) string {
+	name := strings.ToUpper(strings.TrimSpace(raw))
+	name = strings.ReplaceAll(name, "-", "_")
+	name = strings.ReplaceAll(name, ".", "_")
+	name = invalidZarfVariableRunes.ReplaceAllString(name, "_")
+	name = strings.Trim(name, "_")
+	if name == "" {
+		return "VALUE"
+	}
+	return name
+}
+
+func stringPointer(value string) *string {
+	return &value
 }
 
 func buildPortName(index int, port model.Port) string {
@@ -1399,6 +1590,12 @@ func appLabels(appName string, name string) map[string]string {
 		"app.kubernetes.io/name":    name,
 		"app.kubernetes.io/part-of": appName,
 	}
+}
+
+func reloadableAppLabels(appName string, name string) map[string]string {
+	labels := appLabels(appName, name)
+	labels[podReloadLabel] = "true"
+	return labels
 }
 
 func serviceSelector(name string) map[string]string {
@@ -1464,7 +1661,9 @@ var invalidManifestNameRunes = regexp.MustCompile(`[^a-z0-9.-]+`)
 var invalidPortNameRunes = regexp.MustCompile(`[^a-z0-9-]+`)
 var repeatedPortNameHyphens = regexp.MustCompile(`-+`)
 var portNameLetter = regexp.MustCompile(`[a-z]`)
-var invalidSecretVariableRunes = regexp.MustCompile(`[^A-Z0-9_]+`)
+var invalidZarfVariableRunes = regexp.MustCompile(`[^A-Z0-9_]+`)
+var validZarfVariableName = regexp.MustCompile(`^[A-Z0-9_]+$`)
+var portableEnvironmentName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 func sanitizeManifestName(raw string) string {
 	name := strings.ToLower(strings.TrimSpace(raw))
@@ -1475,6 +1674,10 @@ func sanitizeManifestName(raw string) string {
 		return "resource"
 	}
 	return name
+}
+
+func environmentConfigMapName(serviceName string) string {
+	return sanitizeManifestName(serviceName + "-environment")
 }
 
 type objectMeta struct {
@@ -1560,7 +1763,7 @@ type containerSpec struct {
 	Command         []string              `yaml:"command,omitempty"`
 	Args            []string              `yaml:"args,omitempty"`
 	Stdin           bool                  `yaml:"stdin,omitempty"`
-	Env             []envVar              `yaml:"env,omitempty"`
+	EnvFrom         []envFromSource       `yaml:"envFrom,omitempty"`
 	Ports           []containerPort       `yaml:"ports,omitempty"`
 	VolumeMounts    []volumeMountSpec     `yaml:"volumeMounts,omitempty"`
 	LivenessProbe   *probe                `yaml:"livenessProbe,omitempty"`
@@ -1568,9 +1771,12 @@ type containerSpec struct {
 	SecurityContext *securityContext      `yaml:"securityContext,omitempty"`
 }
 
-type envVar struct {
-	Name  string `yaml:"name"`
-	Value string `yaml:"value"`
+type envFromSource struct {
+	ConfigMapRef *configMapEnvSource `yaml:"configMapRef,omitempty"`
+}
+
+type configMapEnvSource struct {
+	Name string `yaml:"name"`
 }
 
 type containerPort struct {
@@ -1724,10 +1930,11 @@ type zarfMetadata struct {
 }
 
 type zarfVariable struct {
-	Name        string `yaml:"name"`
-	Description string `yaml:"description,omitempty"`
-	Prompt      bool   `yaml:"prompt,omitempty"`
-	Sensitive   bool   `yaml:"sensitive,omitempty"`
+	Name        string  `yaml:"name"`
+	Description string  `yaml:"description,omitempty"`
+	Default     *string `yaml:"default,omitempty"`
+	Prompt      bool    `yaml:"prompt,omitempty"`
+	Sensitive   bool    `yaml:"sensitive,omitempty"`
 }
 
 type zarfComponent struct {
@@ -1790,5 +1997,6 @@ type chartMetadata struct {
 // chartValues is the values document written for both the chart defaults
 // (chart/values.yaml) and the Zarf-templated overrides (values/values.yaml).
 type chartValues struct {
-	Secrets map[string]string `yaml:"secrets"`
+	Environment map[string]map[string]string `yaml:"environment,omitempty"`
+	Secrets     map[string]string            `yaml:"secrets"`
 }

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"defenseunicorns/uds-compose-bridge/internal/compose"
+	"defenseunicorns/uds-compose-bridge/internal/model"
 	"defenseunicorns/uds-compose-bridge/internal/render"
 
 	yamlv3 "gopkg.in/yaml.v3"
@@ -761,8 +762,10 @@ configs:
 	}
 
 	configMap := readFile(t, filepath.Join(outDir, "chart", "templates", "configmap-app-config.yaml"))
-	if !strings.Contains(configMap, "key: value") {
-		t.Fatalf("expected configmap to contain rendered config content")
+	for _, want := range []string{"key: value", `uds.dev/pod-reload: "true"`} {
+		if !strings.Contains(configMap, want) {
+			t.Fatalf("expected configmap to contain %q\n%s", want, configMap)
+		}
 	}
 
 	udsPackage := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
@@ -1986,6 +1989,228 @@ secrets:
 		if !strings.Contains(zarfConfig, want) {
 			t.Fatalf("expected zarf.yaml to contain %q\n%s", want, zarfConfig)
 		}
+	}
+}
+
+func TestWritePackageExternalizesServiceEnvironmentThroughConfigMap(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: shop
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    environment:
+      OPTIONAL_SETTING:
+      POSTGRES_HOST: db
+      POSTGRES_PORT: "5432"
+      POSTGRES_PASSWORD_FILE: /run/secrets/postgres-password
+  ui:
+    image: ghcr.io/acme/ui:1.0.0
+  worker:
+    image: ghcr.io/acme/worker:1.0.0
+    environment:
+      LOG_LEVEL: info
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	templatesDir := filepath.Join(outDir, "chart", "templates")
+	configMap := readFile(t, filepath.Join(templatesDir, "configmap-api-environment.yaml"))
+	for _, want := range []string{
+		"name: api-environment",
+		"uds.dev/pod-reload: \"true\"",
+		`POSTGRES_HOST: {{ index .Values.environment "api" "POSTGRES_HOST" | quote }}`,
+		`OPTIONAL_SETTING: {{ index .Values.environment "api" "OPTIONAL_SETTING" | quote }}`,
+		`POSTGRES_PASSWORD_FILE: {{ index .Values.environment "api" "POSTGRES_PASSWORD_FILE" | quote }}`,
+	} {
+		if !strings.Contains(configMap, want) {
+			t.Fatalf("expected environment ConfigMap to contain %q\n%s", want, configMap)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(templatesDir, "configmap-ui-environment.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("expected no environment ConfigMap for ui, stat err = %v", err)
+	}
+	workerConfigMap := readFile(t, filepath.Join(templatesDir, "configmap-worker-environment.yaml"))
+	for _, want := range []string{
+		"name: worker-environment",
+		`LOG_LEVEL: {{ index .Values.environment "worker" "LOG_LEVEL" | quote }}`,
+	} {
+		if !strings.Contains(workerConfigMap, want) {
+			t.Fatalf("expected worker environment ConfigMap to contain %q\n%s", want, workerConfigMap)
+		}
+	}
+
+	deployment := readFile(t, filepath.Join(templatesDir, "deployment-api.yaml"))
+	for _, want := range []string{"envFrom:", "configMapRef:", "name: api-environment"} {
+		if !strings.Contains(deployment, want) {
+			t.Fatalf("expected deployment to contain %q\n%s", want, deployment)
+		}
+	}
+	if strings.Contains(deployment, "POSTGRES_HOST") {
+		t.Fatalf("did not expect literal environment entries on the deployment\n%s", deployment)
+	}
+
+	chartValues := readYAMLMap(t, filepath.Join(outDir, "chart", "values.yaml"))
+	apiValues := mustMap(t, mustMap(t, chartValues["environment"])["api"])
+	if got := apiValues["POSTGRES_HOST"]; got != "db" {
+		t.Fatalf("expected Compose host default, got %#v", got)
+	}
+	if got := apiValues["POSTGRES_PORT"]; got != "5432" {
+		t.Fatalf("expected Compose port default to remain a string, got %#v", got)
+	}
+	if got := apiValues["OPTIONAL_SETTING"]; got != "" {
+		t.Fatalf("expected unset Compose value to default to an empty string, got %#v", got)
+	}
+
+	zarfValues := readFile(t, filepath.Join(outDir, "values", "values.yaml"))
+	for _, want := range []string{
+		"###ZARF_VAR_API_POSTGRES_HOST###",
+		"###ZARF_VAR_API_OPTIONAL_SETTING###",
+		"###ZARF_VAR_API_POSTGRES_PORT###",
+		"###ZARF_VAR_API_POSTGRES_PASSWORD_FILE###",
+		"###ZARF_VAR_WORKER_LOG_LEVEL###",
+	} {
+		if !strings.Contains(zarfValues, want) {
+			t.Fatalf("expected Zarf values to contain %q\n%s", want, zarfValues)
+		}
+	}
+
+	zarfConfig := readFile(t, filepath.Join(outDir, "zarf.yaml"))
+	for _, want := range []string{
+		"name: API_POSTGRES_HOST",
+		"default: db",
+		"name: API_OPTIONAL_SETTING",
+		"default: \"\"",
+		"name: API_POSTGRES_PORT",
+		"default: \"5432\"",
+		"name: API_POSTGRES_PASSWORD_FILE",
+		"default: /run/secrets/postgres-password",
+		"name: WORKER_LOG_LEVEL",
+		"valuesFiles:",
+	} {
+		if !strings.Contains(zarfConfig, want) {
+			t.Fatalf("expected zarf.yaml to contain %q\n%s", want, zarfConfig)
+		}
+	}
+	if strings.Contains(zarfConfig, "prompt: true") || strings.Contains(zarfConfig, "sensitive: true") {
+		t.Fatalf("ordinary environment variables must not prompt or be sensitive\n%s", zarfConfig)
+	}
+}
+
+func TestWritePackageRejectsInvalidEnvironmentExternalization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		app     model.App
+		wantErr string
+	}{
+		{
+			name: "non-portable environment name",
+			app: model.App{
+				Package: model.Package{Name: "shop", Namespace: "shop", Version: "0.1.0"},
+				Services: []model.Service{{
+					Name: "api", Image: "ghcr.io/acme/api:1.0.0",
+					Env: []model.EnvVar{{Name: "DATABASE-URL", Value: "postgres://db"}},
+				}},
+			},
+			wantErr: `invalid environment variable "DATABASE-URL" on service "api"`,
+		},
+		{
+			name: "normalized environment variable collision",
+			app: model.App{
+				Package: model.Package{Name: "shop", Namespace: "shop", Version: "0.1.0"},
+				Services: []model.Service{{
+					Name: "api", Image: "ghcr.io/acme/api:1.0.0",
+					Env: []model.EnvVar{
+						{Name: "LOG_LEVEL", Value: "info"},
+						{Name: "log_level", Value: "debug"},
+					},
+				}},
+			},
+			wantErr: `generates Zarf variable "API_LOG_LEVEL", which conflicts with environment variable "LOG_LEVEL" on service "api"`,
+		},
+		{
+			name: "secret variable collision",
+			app: model.App{
+				Package: model.Package{Name: "shop", Namespace: "shop", Version: "0.1.0"},
+				Services: []model.Service{{
+					Name: "api", Image: "ghcr.io/acme/api:1.0.0",
+					Env: []model.EnvVar{{Name: "TOKEN", Value: "not-a-secret"}},
+				}},
+				Secrets: map[string]model.Secret{"api-token": {Name: "api-token"}},
+			},
+			wantErr: `generates Zarf variable "API_TOKEN", which conflicts with compose secret "api-token"`,
+		},
+		{
+			name: "cross-service variable collision",
+			app: model.App{
+				Package: model.Package{Name: "shop", Namespace: "shop", Version: "0.1.0"},
+				Services: []model.Service{
+					{
+						Name: "api", Image: "ghcr.io/acme/api:1.0.0",
+						Env: []model.EnvVar{{Name: "WORKER_LOG_LEVEL", Value: "info"}},
+					},
+					{
+						Name: "api-worker", Image: "ghcr.io/acme/worker:1.0.0",
+						Env: []model.EnvVar{{Name: "LOG_LEVEL", Value: "debug"}},
+					},
+				},
+			},
+			wantErr: `generates Zarf variable "API_WORKER_LOG_LEVEL", which conflicts with environment variable "WORKER_LOG_LEVEL" on service "api"`,
+		},
+		{
+			name: "reserved environment variable collision",
+			app: model.App{
+				Package: model.Package{Name: "shop", Namespace: "shop", Version: "0.1.0"},
+				Services: []model.Service{{
+					Name: "additional", Image: "ghcr.io/acme/api:1.0.0",
+					Env: []model.EnvVar{{Name: "NETWORK_ALLOW", Value: "custom"}},
+				}},
+			},
+			wantErr: `generates Zarf variable "ADDITIONAL_NETWORK_ALLOW", which conflicts with reserved package variable`,
+		},
+		{
+			name: "reserved secret variable collision",
+			app: model.App{
+				Package:  model.Package{Name: "shop", Namespace: "shop", Version: "0.1.0"},
+				Services: []model.Service{{Name: "api", Image: "ghcr.io/acme/api:1.0.0"}},
+				Secrets: map[string]model.Secret{
+					"additional-network-allow": {Name: "additional-network-allow"},
+				},
+			},
+			wantErr: `compose secret "additional-network-allow" generates Zarf variable "ADDITIONAL_NETWORK_ALLOW", which conflicts with reserved package variable`,
+		},
+		{
+			name: "compose config map collision",
+			app: model.App{
+				Package: model.Package{Name: "shop", Namespace: "shop", Version: "0.1.0"},
+				Services: []model.Service{{
+					Name: "api", Image: "ghcr.io/acme/api:1.0.0",
+					Env: []model.EnvVar{{Name: "LOG_LEVEL", Value: "info"}},
+				}},
+				Configs: map[string]model.Config{
+					"api-environment": {Name: "api-environment", Content: "config"},
+				},
+			},
+			wantErr: `environment ConfigMap "api-environment" for service "api" conflicts with compose config "api-environment"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := render.WritePackage(t.TempDir(), tt.app)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("WritePackage() error = %v, want error containing %q", err, tt.wantErr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

  Closes #72. Based on spike implementation 2b3e34d.

  Treats resolved Docker Compose service environment values as deploy-time configuration instead of embedding them directly in Deployment manifests.

  Each environment value becomes a non-sensitive Zarf variable named `<SERVICE>_<ENVIRONMENT_VARIABLE>`, with the value resolved by `docker compose config` retained as
  its default.

  ## Changes

  - Generate one `<service>-environment` ConfigMap for each service with environment values.
  - Attach generated ConfigMaps to their workloads using `envFrom`.
  - Omit environment ConfigMaps for services without environment values.
  - Add `uds.dev/pod-reload: "true"` to generated environment and Compose configuration ConfigMaps.
  - Generate Zarf-templated Helm values for service environment variables.
  - Preserve resolved Compose values, including empty strings, as Zarf variable defaults.
  - Validate portable environment-variable names.
  - Reject generated Zarf variable collisions across:
    - Services
    - Compose secrets
    - Reserved package variables such as `ADDITIONAL_NETWORK_ALLOW`
  - Reject collisions between generated environment ConfigMaps and Compose configuration ConfigMaps.
  - Update tests and documentation for the new behavior.

  This PR is intentionally scoped to environment externalization and excludes unrelated features from the original integration spike branch.

  ## Validation

  - `go test ./...`
  - `go test -race ./...`
  - `go vet ./...`
  - Built the translator image from the updated source.
  - Converted `examples/full` using the locally built translator.
  - Successfully rendered the generated package with `zarf dev inspect manifests`.
  - Verified deploy-time overrides render into the service environment ConfigMap.
