### PR TITLE
feat(network): add deploy-time network allow configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ zarf package create out/
 zarf package deploy zarf-package-wordpress-*.tar.zst
 ```
 
-The transformation writes a Helm chart to `out/chart/`, a Zarf package definition to `out/zarf.yaml`, and `out/values/` when the Compose file declares secrets or service environment variables. Services with `build:` are built during `zarf package create` through a generated Buildx Bake definition. See [Compose support](docs/compose-support.md#local-dockerfile-builds) for Docker Compose version-specific conversion steps.
+The transformation writes a Helm chart to `out/chart/`, a Zarf package definition to `out/zarf.yaml`, and deploy-time configuration to `out/values/`. Services with `build:` are built during `zarf package create` through a generated Buildx Bake definition. See [Compose support](docs/compose-support.md#local-dockerfile-builds) for Docker Compose version-specific conversion steps.
 
 ## Documentation
 

--- a/docs/compose-support.md
+++ b/docs/compose-support.md
@@ -31,6 +31,12 @@ The bridge renders one `<service>-environment` ConfigMap for each service with e
 
 ConfigMaps do not protect sensitive data; use Compose `secrets:` for credentials and other confidential values. Environment names must use the portable `[A-Za-z_][A-Za-z0-9_]*` form. Generated Zarf variable names must also be unique across all services, secrets, and reserved package variables such as `ADDITIONAL_NETWORK_ALLOW`; conversion fails rather than emitting an ambiguous package when names collide.
 
+## Deploy-time network access
+
+Every generated package exposes the non-sensitive Zarf variable `ADDITIONAL_NETWORK_ALLOW`, defaulting to `[]`. Its value must be a YAML array of UDS network allow rules. The rules are appended to the generated UDS Package resource so operators can provide environment-specific ingress or egress without modifying the Compose application or rebuilding the package.
+
+Rules declared under `x-uds.network.allow` remain static package defaults for connectivity that Compose cannot express. Compose-derived and static rules are rendered first; `ADDITIONAL_NETWORK_ALLOW` entries are appended afterward.
+
 ## Local Dockerfile builds
 
 Docker Compose v5.5.0 or later can pass a build-only service through Compose Bridge without trying to pull Compose's default image name. For earlier Compose versions, run `docker compose build` before conversion so that default image exists locally:

--- a/docs/uds-package.md
+++ b/docs/uds-package.md
@@ -4,12 +4,12 @@ The bridge maps the [Compose Specification](https://compose-spec.io/) to Kuberne
 
 For services with `build:`, the bridge also writes `out/build.compose.yaml`. Zarf `onCreate` actions use Buildx Bake to build those services into OCI archives under `out/image-archives/`, and the component's `imageArchives` entries add them to the package.
 
-Secrets are rendered from chart values rather than baked into templates. Service environment values are exposed as non-sensitive Zarf variables and rendered into per-service ConfigMaps. The bridge writes `out/values/values.yaml` with `###ZARF_VAR_*###` placeholders for both forms of deploy-time configuration, references it through `charts[].valuesFiles`, and retains their defaults, prompts, and sensitivity settings in the Zarf package's `variables:`.
+Secrets are rendered from chart values rather than baked into templates. Service environment values are exposed as non-sensitive Zarf variables and rendered into per-service ConfigMaps. Every package also exposes `ADDITIONAL_NETWORK_ALLOW` for deploy-time UDS network rules. The bridge writes `out/values/values.yaml` with `###ZARF_VAR_*###` placeholders for these deploy-time values, references it through `charts[].valuesFiles`, and retains their defaults, prompts, indentation, and sensitivity settings in the Zarf package's `variables:`.
 
 ## Inferred behavior
 
 - **Expose:** Services with published `ports:` are exposed on the tenant gateway. For multi-port services, the bridge prefers Compose `app_protocol` or `name` values indicating web traffic, then falls back to the first published port.
-- **Network allow:** Intra-namespace ingress and egress rules are always included so services in the namespace can communicate.
+- **Network allow:** Intra-namespace ingress and egress rules are always included so services in the namespace can communicate. Static `x-uds.network.allow` entries follow inferred rules, and deploy-time `ADDITIONAL_NETWORK_ALLOW` entries are appended last.
 - **SSO:** A Keycloak client is generated for the first exposed service and omitted when no services are exposed.
 - **Policy exemptions:** Services requiring UDS policy exceptions produce `chart/templates/uds-exemption.yaml`.
 - **Monitoring:** Monitoring is opt-in through `x-uds.monitor[]`.

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -35,9 +35,11 @@ const (
 	composeNetworkLabelPrefix = "network.compose.bridge.uds.dev/"
 	podReloadLabel            = "uds.dev/pod-reload"
 	// additionalNetworkAllowVariable is reserved for package-level deploy-time
-	// network configuration (see issue #73). Environment and secret variables
-	// must not claim the same Zarf variable name.
-	additionalNetworkAllowVariable = "ADDITIONAL_NETWORK_ALLOW"
+	// network configuration. Environment and secret variables must not claim the
+	// same Zarf variable name.
+	additionalNetworkAllowVariable    = "ADDITIONAL_NETWORK_ALLOW"
+	additionalNetworkAllowPlaceholder = "__HELM_ADDITIONAL_NETWORK_ALLOW__"
+	zarfNetworkAllowPlaceholder       = "__ZARF_ADDITIONAL_NETWORK_ALLOW__"
 )
 
 func WritePackage(root string, app model.App) error {
@@ -168,7 +170,7 @@ func WritePackage(root string, app model.App) error {
 	if err != nil {
 		return err
 	}
-	if err := writeYAMLFile(filepath.Join(templatesDir, "uds-package.yaml"), udsPackage); err != nil {
+	if err := writeUDSPackageTemplate(filepath.Join(templatesDir, "uds-package.yaml"), udsPackage); err != nil {
 		return err
 	}
 
@@ -185,15 +187,12 @@ func WritePackage(root string, app model.App) error {
 		return err
 	}
 
-	hasDeployValues := len(secretValueKeys) > 0 || len(environmentVariables) > 0
-	if hasDeployValues {
-		valuesPath := filepath.Join(root, filepath.FromSlash(zarfValuesRel))
-		if err := os.MkdirAll(filepath.Dir(valuesPath), 0o755); err != nil {
-			return fmt.Errorf("create directory %s: %w", filepath.Dir(valuesPath), err)
-		}
-		if err := writeChartValues(valuesPath, app, secretValueKeys, environmentVariables, true); err != nil {
-			return err
-		}
+	valuesPath := filepath.Join(root, filepath.FromSlash(zarfValuesRel))
+	if err := os.MkdirAll(filepath.Dir(valuesPath), 0o755); err != nil {
+		return fmt.Errorf("create directory %s: %w", filepath.Dir(valuesPath), err)
+	}
+	if err := writeChartValues(valuesPath, app, secretValueKeys, environmentVariables, true); err != nil {
+		return err
 	}
 
 	if hasBuildServices(app) {
@@ -207,7 +206,7 @@ func WritePackage(root string, app model.App) error {
 		images = append(images, buildComponentImages(svc, servicePorts)...)
 	}
 
-	if err := writeZarfConfig(filepath.Join(root, "zarf.yaml"), app, secretVariables, environmentVariables, dedupeStrings(images), hasDeployValues); err != nil {
+	if err := writeZarfConfig(filepath.Join(root, "zarf.yaml"), app, secretVariables, environmentVariables, dedupeStrings(images)); err != nil {
 		return err
 	}
 
@@ -417,6 +416,31 @@ func writeEnvironmentConfigMapTemplate(path string, app model.App, svc model.Ser
 	return nil
 }
 
+// writeUDSPackageTemplate preserves the statically generated network rules and
+// appends deploy-time rules supplied through the chart value.
+func writeUDSPackageTemplate(path string, manifest udsPackageManifest) error {
+	manifest.Spec.Network.Allow = append(manifest.Spec.Network.Allow, additionalNetworkAllowPlaceholder)
+	marshaled, err := yamlv3.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("marshal yaml for %s: %w", path, err)
+	}
+
+	placeholderLine := "            - " + additionalNetworkAllowPlaceholder
+	templateBlock := strings.Join([]string{
+		"            {{- with .Values.additionalNetworkAllow }}",
+		"            {{ toYaml . | nindent 12 }}",
+		"            {{- end }}",
+	}, "\n")
+	rendered := strings.Replace(string(marshaled), placeholderLine, templateBlock, 1)
+	if rendered == string(marshaled) {
+		return fmt.Errorf("render additional network allow template in %s: placeholder not found", path)
+	}
+	if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil {
+		return fmt.Errorf("write file %s: %w", path, err)
+	}
+	return nil
+}
+
 // writeChartMetadata writes the generated chart's Chart.yaml.
 func writeChartMetadata(path string, app model.App) error {
 	return writeYAMLFile(path, chartMetadata{
@@ -438,7 +462,15 @@ func writeChartValues(
 	environmentVariables map[string]map[string]string,
 	placeholder bool,
 ) error {
-	environment := map[string]map[string]string{}
+	values := chartValues{
+		AdditionalNetworkAllow: []any{},
+		Environment:            map[string]map[string]string{},
+		Secrets:                map[string]string{},
+	}
+	if placeholder {
+		values.AdditionalNetworkAllow = zarfNetworkAllowPlaceholder
+	}
+
 	for _, svc := range app.Services {
 		if len(svc.Env) == 0 {
 			continue
@@ -451,18 +483,34 @@ func writeChartValues(
 			}
 			serviceValues[item.Name] = value
 		}
-		environment[svc.Name] = serviceValues
+		values.Environment[svc.Name] = serviceValues
 	}
 
-	secrets := map[string]string{}
 	for _, key := range secretKeys {
 		if placeholder {
-			secrets[key] = fmt.Sprintf("###ZARF_VAR_%s###", key)
+			values.Secrets[key] = fmt.Sprintf("###ZARF_VAR_%s###", key)
 		} else {
-			secrets[key] = ""
+			values.Secrets[key] = ""
 		}
 	}
-	return writeYAMLFile(path, chartValues{Environment: environment, Secrets: secrets})
+
+	marshaled, err := yamlv3.Marshal(values)
+	if err != nil {
+		return fmt.Errorf("marshal yaml for %s: %w", path, err)
+	}
+	rendered := string(marshaled)
+	if placeholder {
+		placeholderLine := "additionalNetworkAllow: " + zarfNetworkAllowPlaceholder
+		variableBlock := "additionalNetworkAllow:\n  ###ZARF_VAR_" + additionalNetworkAllowVariable + "###"
+		rendered = strings.Replace(rendered, placeholderLine, variableBlock, 1)
+		if rendered == string(marshaled) {
+			return fmt.Errorf("render additional network allow Zarf variable in %s: placeholder not found", path)
+		}
+	}
+	if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil {
+		return fmt.Errorf("write file %s: %w", path, err)
+	}
+	return nil
 }
 
 func writeZarfConfig(
@@ -471,9 +519,13 @@ func writeZarfConfig(
 	secretVariables map[string]string,
 	environmentVariables map[string]map[string]string,
 	images []string,
-	hasDeployValues bool,
 ) error {
-	variables := []zarfVariable{}
+	variables := []zarfVariable{{
+		Name:        additionalNetworkAllowVariable,
+		Description: "Additional UDS network allow rules (YAML array)",
+		Default:     stringPointer("[]"),
+		AutoIndent:  true,
+	}}
 	for _, secretName := range sortedSecretNames(app.Secrets) {
 		variables = append(variables, zarfVariable{
 			Name:        secretVariables[secretName],
@@ -508,9 +560,9 @@ func writeZarfConfig(
 		Namespace: app.Package.Namespace,
 		LocalPath: chartDirName,
 		Version:   app.Package.Version,
-	}
-	if hasDeployValues {
-		chart.ValuesFiles = []string{zarfValuesRel}
+		ValuesFiles: []string{
+			zarfValuesRel,
+		},
 	}
 	component := zarfComponent{
 		Name:        app.Package.Name,
@@ -674,15 +726,15 @@ func buildUDSPackage(app model.App) (udsPackageManifest, error) {
 	}, nil
 }
 
-func buildNetworkAllowRules(app model.App) []map[string]any {
+func buildNetworkAllowRules(app model.App) []any {
 	if !hasDistinctNetworkMemberships(app.Services) {
-		return []map[string]any{
-			{"direction": "Ingress", "remoteGenerated": "IntraNamespace"},
-			{"direction": "Egress", "remoteGenerated": "IntraNamespace"},
+		return []any{
+			map[string]any{"direction": "Ingress", "remoteGenerated": "IntraNamespace"},
+			map[string]any{"direction": "Egress", "remoteGenerated": "IntraNamespace"},
 		}
 	}
 
-	var allow []map[string]any
+	var allow []any
 	for _, network := range sortedServiceNetworks(app.Services) {
 		labelKey := composeNetworkLabelPrefix + network
 		for _, direction := range []string{"Ingress", "Egress"} {
@@ -1935,9 +1987,9 @@ type udsPackageSpec struct {
 }
 
 type udsNetwork struct {
-	ServiceMesh udsServiceMesh   `yaml:"serviceMesh"`
-	Expose      []any            `yaml:"expose,omitempty"`
-	Allow       []map[string]any `yaml:"allow"`
+	ServiceMesh udsServiceMesh `yaml:"serviceMesh"`
+	Expose      []any          `yaml:"expose,omitempty"`
+	Allow       []any          `yaml:"allow"`
 }
 
 type udsServiceMesh struct {
@@ -1964,6 +2016,7 @@ type zarfVariable struct {
 	Default     *string `yaml:"default,omitempty"`
 	Prompt      bool    `yaml:"prompt,omitempty"`
 	Sensitive   bool    `yaml:"sensitive,omitempty"`
+	AutoIndent  bool    `yaml:"autoIndent,omitempty"`
 }
 
 type zarfComponent struct {
@@ -2026,6 +2079,7 @@ type chartMetadata struct {
 // chartValues is the values document written for both the chart defaults
 // (chart/values.yaml) and the Zarf-templated overrides (values/values.yaml).
 type chartValues struct {
-	Environment map[string]map[string]string `yaml:"environment,omitempty"`
-	Secrets     map[string]string            `yaml:"secrets"`
+	AdditionalNetworkAllow any                          `yaml:"additionalNetworkAllow"`
+	Environment            map[string]map[string]string `yaml:"environment,omitempty"`
+	Secrets                map[string]string            `yaml:"secrets"`
 }

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -638,7 +638,7 @@ networks:
 		}
 	}
 
-	udsPackage := readYAMLMap(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
+	udsPackage := readUDSPackageYAMLMap(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	spec := mustMap(t, udsPackage["spec"])
 	network := mustMap(t, spec["network"])
 	allows, ok := network["allow"].([]any)
@@ -702,7 +702,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	udsPackage := readYAMLMap(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
+	udsPackage := readUDSPackageYAMLMap(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	spec := mustMap(t, udsPackage["spec"])
 	network := mustMap(t, spec["network"])
 	allows, ok := network["allow"].([]any)
@@ -719,6 +719,104 @@ services:
 	deployment := readFile(t, filepath.Join(outDir, "chart", "templates", "deployment-api.yaml"))
 	if strings.Contains(deployment, "network.compose.bridge.uds.dev/") {
 		t.Fatalf("did not expect membership labels for a shared network\n%s", deployment)
+	}
+}
+
+func TestWritePackageAddsDeployTimeNetworkAllow(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: demo
+x-uds:
+  network:
+    allow:
+      - direction: Egress
+        selector:
+          app.kubernetes.io/name: api
+        remoteNamespace: platform-service
+        ports:
+          - 8443
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	udsPackagePath := filepath.Join(outDir, "chart", "templates", "uds-package.yaml")
+	udsPackage := readFile(t, udsPackagePath)
+	for _, want := range []string{
+		"remoteNamespace: platform-service",
+		"app.kubernetes.io/name: api",
+		"{{- with .Values.additionalNetworkAllow }}",
+		"{{ toYaml . | nindent 12 }}",
+	} {
+		if !strings.Contains(udsPackage, want) {
+			t.Fatalf("expected UDS Package template to contain %q\n%s", want, udsPackage)
+		}
+	}
+	staticIndex := strings.Index(udsPackage, "remoteNamespace: platform-service")
+	templateIndex := strings.Index(udsPackage, "{{- with .Values.additionalNetworkAllow }}")
+	if staticIndex < 0 || templateIndex < 0 || staticIndex >= templateIndex {
+		t.Fatalf("expected deploy-time rules after static rules\n%s", udsPackage)
+	}
+
+	parsedPackage := readUDSPackageYAMLMap(t, udsPackagePath)
+	network := mustMap(t, mustMap(t, parsedPackage["spec"])["network"])
+	allows, ok := network["allow"].([]any)
+	if !ok || len(allows) != 3 {
+		t.Fatalf("expected two inferred rules and one static rule, got %#v", network["allow"])
+	}
+
+	chartValues := readYAMLMap(t, filepath.Join(outDir, "chart", "values.yaml"))
+	additionalAllow, ok := chartValues["additionalNetworkAllow"].([]any)
+	if !ok || len(additionalAllow) != 0 {
+		t.Fatalf("expected empty additionalNetworkAllow chart default, got %#v", chartValues["additionalNetworkAllow"])
+	}
+
+	zarfValues := readFile(t, filepath.Join(outDir, "values", "values.yaml"))
+	variableToken := "###ZARF_VAR_ADDITIONAL_NETWORK_ALLOW###"
+	if !strings.Contains(zarfValues, "additionalNetworkAllow:\n  "+variableToken) {
+		t.Fatalf("expected raw structured Zarf substitution\n%s", zarfValues)
+	}
+	if strings.Contains(zarfValues, "'"+variableToken+"'") {
+		t.Fatalf("additional network allow substitution must not be quoted\n%s", zarfValues)
+	}
+
+	for name, substituted := range map[string]string{
+		"empty": strings.Replace(zarfValues, variableToken, "[]", 1),
+		"multiline": strings.Replace(
+			zarfValues,
+			"  "+variableToken,
+			"  - direction: Egress\n    remoteNamespace: logging\n    ports:\n      - 443",
+			1,
+		),
+	} {
+		var values map[string]any
+		if err := yamlv3.Unmarshal([]byte(substituted), &values); err != nil {
+			t.Fatalf("expected %s network allow substitution to be valid YAML: %v\n%s", name, err, substituted)
+		}
+		if _, ok := values["additionalNetworkAllow"].([]any); !ok {
+			t.Fatalf("expected %s network allow substitution to remain a list, got %#v", name, values["additionalNetworkAllow"])
+		}
+	}
+
+	zarfConfig := readFile(t, filepath.Join(outDir, "zarf.yaml"))
+	for _, want := range []string{
+		"name: ADDITIONAL_NETWORK_ALLOW",
+		"default: '[]'",
+		"autoIndent: true",
+		"values/values.yaml",
+	} {
+		if !strings.Contains(zarfConfig, want) {
+			t.Fatalf("expected zarf.yaml to contain %q\n%s", want, zarfConfig)
+		}
 	}
 }
 
@@ -1689,7 +1787,7 @@ services:
 		t.Fatalf("WritePackage() error = %v", err)
 	}
 
-	udsPackage := readYAMLMap(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
+	udsPackage := readUDSPackageYAMLMap(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
 	spec := mustMap(t, udsPackage["spec"])
 	caBundle := mustMap(t, spec["caBundle"])
 	configMap := mustMap(t, caBundle["configMap"])
@@ -2114,12 +2212,15 @@ services:
 	if strings.Contains(zarfConfig, "manifests:") {
 		t.Fatalf("did not expect manifest-based zarf config\n%s", zarfConfig)
 	}
-	// No secrets: no Zarf values file and no valuesFiles reference.
-	if _, err := os.Stat(filepath.Join(outDir, "values")); !os.IsNotExist(err) {
-		t.Fatalf("did not expect values/ directory for a package without secrets")
+	// Every package has a values file for deploy-time additional network rules.
+	zarfValues := readFile(t, filepath.Join(outDir, "values", "values.yaml"))
+	if !strings.Contains(zarfValues, "additionalNetworkAllow:\n  ###ZARF_VAR_ADDITIONAL_NETWORK_ALLOW###") {
+		t.Fatalf("expected deploy-time network allow placeholder\n%s", zarfValues)
 	}
-	if strings.Contains(zarfConfig, "valuesFiles") {
-		t.Fatalf("did not expect valuesFiles for a package without secrets\n%s", zarfConfig)
+	for _, want := range []string{"name: ADDITIONAL_NETWORK_ALLOW", "default: '[]'", "autoIndent: true", "valuesFiles:"} {
+		if !strings.Contains(zarfConfig, want) {
+			t.Fatalf("expected zarf.yaml to contain %q\n%s", want, zarfConfig)
+		}
 	}
 }
 
@@ -2398,7 +2499,7 @@ func TestWritePackageRejectsInvalidEnvironmentExternalization(t *testing.T) {
 
 func firstExposeRule(t *testing.T, path string) map[string]any {
 	t.Helper()
-	udsPackage := readYAMLMap(t, path)
+	udsPackage := readUDSPackageYAMLMap(t, path)
 	spec := mustMap(t, udsPackage["spec"])
 	network := mustMap(t, spec["network"])
 	exposes, ok := network["expose"].([]any)
@@ -2406,6 +2507,25 @@ func firstExposeRule(t *testing.T, path string) map[string]any {
 		t.Fatalf("expected at least one expose rule in %s, got %#v", path, network["expose"])
 	}
 	return mustMap(t, exposes[0])
+}
+
+func readUDSPackageYAMLMap(t *testing.T, path string) map[string]any {
+	t.Helper()
+	content := readFile(t, path)
+	templateBlock := strings.Join([]string{
+		"            {{- with .Values.additionalNetworkAllow }}",
+		"            {{ toYaml . | nindent 12 }}",
+		"            {{- end }}",
+	}, "\n")
+	if !strings.Contains(content, templateBlock) {
+		t.Fatalf("expected additional network allow template in %s\n%s", path, content)
+	}
+	content = strings.Replace(content, templateBlock, "", 1)
+	var out map[string]any
+	if err := yamlv3.Unmarshal([]byte(content), &out); err != nil {
+		t.Fatalf("unmarshal Helm-stripped yaml %s: %v", path, err)
+	}
+	return out
 }
 
 func readFile(t *testing.T, path string) string {


### PR DESCRIPTION
## Description

  Closes #73. Based on spike implementation c19da9d.

  Adds deploy-time configuration for additional UDS network allow rules without requiring the package to be regenerated.

  Every generated package exposes a non-sensitive `ADDITIONAL_NETWORK_ALLOW` Zarf variable. Its default value is an empty list, and supplied rules are appended after
  network rules inferred from the Compose configuration or declared through `x-uds`.

  ## Changes

  - Add the `ADDITIONAL_NETWORK_ALLOW` Zarf variable to every generated package.
  - Default the variable to `[]` so packages remain valid without additional rules.
  - Enable Zarf `autoIndent` for multiline YAML values.
  - Add `additionalNetworkAllow` to the generated Helm values.
  - Render additional allow rules after inferred and explicitly configured network rules.
  - Preserve existing network rules when deploy-time rules are supplied.
  - Always generate and reference the package values file.
  - Update tests and documentation for the new behavior.

  This PR is intentionally scoped to deploy-time network allow configuration and excludes unrelated functionality from the original spike commit.

  ## Validation

  - `go test ./...`
  - `go test -race ./...`
  - `go vet ./...`
  - `git diff --check`
  - Built the translator image from the updated source.
  - Converted `examples/full` using the locally built translator.
  - Successfully ran `zarf dev lint` against the generated package.
  - Successfully rendered the generated package with `zarf dev inspect manifests`.
  - Verified rendering with the default empty list, an explicitly blank value, and multiline additional network rules.
  - Verified supplied rules are appended after the package’s existing network allow rules.
