### PR TITLE
feat(compose): exclude optional development dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ zarf package deploy zarf-package-wordpress-*.tar.zst
 
 The transformation writes a Helm chart to `out/chart/`, a Zarf package definition to `out/zarf.yaml`, and deploy-time configuration to `out/values/`. Services with `build:` are built during `zarf package create` through a generated Buildx Bake definition. See [Compose support](docs/compose-support.md#local-dockerfile-builds) for Docker Compose version-specific conversion steps.
 
+Mark a local-development dependency with long-syntax `depends_on` and
+`required: false` to keep it available to `docker compose up` while omitting it
+and its exclusive resources from the generated package.
+
 ## Documentation
 
 > [!TIP]

--- a/docs/compose-support.md
+++ b/docs/compose-support.md
@@ -10,7 +10,7 @@
 | `secrets:`                                                       | Converted to Kubernetes Secrets.                                                                                                                                                                                                                                                |
 | `configs:`                                                       | Converted to reloadable ConfigMaps. Must use inline `content:` (no external file references).                                                                                                                                                                                   |
 | `environment:`, `env_file:`                                      | Resolved by `docker compose config`, exposed as non-sensitive Zarf variables, and rendered into a reloadable ConfigMap consumed by the service through `envFrom`.                                                                                                               |
-| `depends_on:`                                                    | Converted to init-container wait logic using `netcat` (busybox). The dependency must declare a port.                                                                                                                                                                            |
+| `depends_on:`                                                    | Required dependencies become init-container wait logic using `netcat` (busybox). A service referenced only through long-syntax dependencies with `required: false` is excluded as a development-only service. Included dependencies must declare a port.                                                                                       |
 | `healthcheck:`                                                   | `CMD` and `CMD-SHELL` forms convert to Kubernetes liveness probes.                                                                                                                                                                                                              |
 | `container_name:`                                                | Ignored with a warning. Kubernetes Service and Deployment names come from the Compose service name.                                                                                                                                                                             |
 | `stdin_open:`                                                    | Maps to the Kubernetes container `stdin` field.                                                                                                                                                                                                                                 |
@@ -21,7 +21,38 @@
 | Bind mounts                                                      | Skipped during conversion with a warning because host paths do not have a portable Kubernetes equivalent. Use named `volumes:`, `configs:`, or `secrets:` for data that should be rendered into the chart.                                                                       |
 | `user:`, `privileged:`, `cap_add:`, `cap_drop:`, `security_opt:` | Reflected in the container security context where applicable. Settings that require UDS policy exceptions also generate a `chart/templates/uds-exemption.yaml`.                                                                                                                 |
 
-External configs are not supported. A `configs:` entry must define inline `content:`.
+External configs referenced by an included service are not supported. A
+packaged `configs:` entry must define inline `content:`.
+
+## Excluding development services
+
+Use long-syntax `depends_on` with `required: false` for a dependency that is
+useful during local Compose development but should not be included in the
+generated package:
+
+```yaml
+services:
+  api:
+    image: example/api:1.0.0
+    depends_on:
+      db:
+        condition: service_healthy
+        required: false
+
+  db:
+    image: postgres:18
+```
+
+Compose still starts `db` during `docker compose up`. The bridge excludes it
+when every `depends_on` reference to `db` has `required: false`. Any required
+reference keeps the service in the package, and services that are never
+referenced remain included.
+
+Excluded services do not generate workloads, Services, images, dependency
+waits, policy exemptions, or other package content. Volumes, configs, and
+secrets used only by excluded services are pruned; resources shared with an
+included service remain. Explicit `x-uds.network.expose`, `x-uds.monitor`, and
+build `additional_contexts` entries must not reference an excluded service.
 
 ## Runtime configuration
 

--- a/docs/uds-package.md
+++ b/docs/uds-package.md
@@ -13,6 +13,7 @@ Secrets are rendered from chart values rather than baked into templates. Service
 - **SSO:** A Keycloak client is generated for the first exposed service and omitted when no services are exposed.
 - **Policy exemptions:** Services requiring UDS policy exceptions produce `chart/templates/uds-exemption.yaml`.
 - **Monitoring:** Monitoring is opt-in through `x-uds.monitor[]`.
+- **Development dependencies:** Services referenced only by `depends_on` entries with `required: false` are omitted along with resources used exclusively by them.
 
 ## Extension keys
 

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -66,11 +66,42 @@ func loadCanonicalYAML(data []byte, sourcePath string) (model.App, error) {
 	if err != nil {
 		return model.App{}, fmt.Errorf("decode canonical compose yaml: %w", err)
 	}
-	if err := validateCompatibility(*project, raw); err != nil {
+	excludedServices := findExcludedServices(*project)
+	if err := validateCompatibility(*project, raw, excludedServices); err != nil {
 		return model.App{}, err
 	}
 
-	return loadProject(*project, raw)
+	return loadProject(*project, raw, excludedServices)
+}
+
+// findExcludedServices identifies development-only dependencies. A service is
+// excluded only when it is referenced by depends_on and every reference marks
+// it as not required. Unreferenced services and services with any required
+// reference remain part of the package.
+func findExcludedServices(project types.Project) map[string]struct{} {
+	type references struct {
+		seen     bool
+		required bool
+	}
+
+	dependencyReferences := map[string]references{}
+	for _, service := range project.Services {
+		for dependencyName, dependency := range service.DependsOn {
+			refs := dependencyReferences[dependencyName]
+			refs.seen = true
+			refs.required = refs.required || dependency.Required
+			dependencyReferences[dependencyName] = refs
+		}
+	}
+
+	excluded := map[string]struct{}{}
+	for serviceName := range project.Services {
+		refs := dependencyReferences[serviceName]
+		if refs.seen && !refs.required {
+			excluded[serviceName] = struct{}{}
+		}
+	}
+	return excluded
 }
 
 func loadWorkingDir(sourcePath string) string {
@@ -84,7 +115,7 @@ func loadWorkingDir(sourcePath string) string {
 	return wd
 }
 
-func loadProject(project types.Project, raw map[string]any) (model.App, error) {
+func loadProject(project types.Project, raw map[string]any, excludedServices map[string]struct{}) (model.App, error) {
 	if len(project.Services) == 0 {
 		return model.App{}, fmt.Errorf("canonical compose model has no services")
 	}
@@ -127,6 +158,7 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 	sort.Strings(keys)
 
 	serviceAliases := map[string]string{}
+	excludedAliases := map[string]struct{}{}
 	for _, key := range keys {
 		normalized, err := normalizeName(key)
 		if err != nil {
@@ -134,6 +166,10 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 		}
 		registerAlias(serviceAliases, key, normalized)
 		registerAlias(serviceAliases, normalized, normalized)
+		if _, excluded := excludedServices[key]; excluded {
+			excludedAliases[key] = struct{}{}
+			excludedAliases[normalized] = struct{}{}
+		}
 	}
 	canonicalServices, canonicalSecrets, err := canonicalBuildMaps(project)
 	if err != nil {
@@ -144,6 +180,9 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 	buildSecrets := map[string]any{}
 
 	for _, key := range keys {
+		if _, excluded := excludedServices[key]; excluded {
+			continue
+		}
 		rawSvc := project.Services[key]
 		serviceName, _ := resolveAlias(serviceAliases, key)
 
@@ -167,7 +206,7 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 		if err != nil {
 			return model.App{}, fmt.Errorf("service %q configs: %w", key, err)
 		}
-		dependsOn, err := parseDependsOn(rawSvc.DependsOn, serviceAliases)
+		dependsOn, err := parseDependsOn(rawSvc.DependsOn, serviceAliases, excludedAliases)
 		if err != nil {
 			return model.App{}, fmt.Errorf("service %q depends_on: %w", key, err)
 		}
@@ -177,6 +216,9 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 		if rawSvc.Build != nil {
 			buildConfig, err := canonicalBuildConfig(canonicalServices, key, serviceAliases)
 			if err != nil {
+				return model.App{}, err
+			}
+			if err := rejectExcludedBuildContexts(key, buildConfig, excludedAliases); err != nil {
 				return model.App{}, err
 			}
 			image = builtImageReference(packageCfg, serviceName)
@@ -223,6 +265,16 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 		})
 	}
 
+	volumes, secrets, configs = retainReferencedResources(services, volumes, secrets, configs)
+	for name, config := range configs {
+		if config.External && strings.TrimSpace(config.Content) == "" {
+			return model.App{}, fmt.Errorf("external compose config %q is not supported", name)
+		}
+	}
+	if err := validateExcludedPackageReferences(packageCfg, excludedAliases); err != nil {
+		return model.App{}, err
+	}
+
 	return model.App{
 		Package:      packageCfg,
 		Services:     services,
@@ -231,6 +283,90 @@ func loadProject(project types.Project, raw map[string]any) (model.App, error) {
 		Configs:      configs,
 		BuildSecrets: buildSecrets,
 	}, nil
+}
+
+func rejectExcludedBuildContexts(serviceName string, build map[string]any, excluded map[string]struct{}) error {
+	contexts, ok := asMap(build["additional_contexts"])
+	if !ok {
+		return nil
+	}
+	for _, value := range contexts {
+		reference, ok := value.(string)
+		if !ok || !strings.HasPrefix(reference, "service:") {
+			continue
+		}
+		dependency := strings.TrimPrefix(reference, "service:")
+		if _, isExcluded := excluded[dependency]; isExcluded {
+			return fmt.Errorf("service %q build references excluded service %q through additional_contexts", serviceName, dependency)
+		}
+	}
+	return nil
+}
+
+func retainReferencedResources(
+	services []model.Service,
+	volumes map[string]model.Volume,
+	secrets map[string]model.Secret,
+	configs map[string]model.Config,
+) (map[string]model.Volume, map[string]model.Secret, map[string]model.Config) {
+	volumeRefs := map[string]struct{}{}
+	secretRefs := map[string]struct{}{}
+	configRefs := map[string]struct{}{}
+	for _, service := range services {
+		for _, volume := range service.Volumes {
+			volumeRefs[volume.Name] = struct{}{}
+		}
+		for _, secret := range service.Secrets {
+			secretRefs[secret.Source] = struct{}{}
+		}
+		for _, config := range service.Configs {
+			configRefs[config.Source] = struct{}{}
+		}
+	}
+
+	retainedVolumes := map[string]model.Volume{}
+	for name, volume := range volumes {
+		if _, referenced := volumeRefs[name]; referenced {
+			retainedVolumes[name] = volume
+		}
+	}
+	retainedSecrets := map[string]model.Secret{}
+	for name, secret := range secrets {
+		if _, referenced := secretRefs[name]; referenced {
+			retainedSecrets[name] = secret
+		}
+	}
+	retainedConfigs := map[string]model.Config{}
+	for name, config := range configs {
+		if _, referenced := configRefs[name]; referenced {
+			retainedConfigs[name] = config
+		}
+	}
+	return retainedVolumes, retainedSecrets, retainedConfigs
+}
+
+func validateExcludedPackageReferences(pkg model.Package, excluded map[string]struct{}) error {
+	for _, raw := range pkg.NetworkExpose {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		service := strings.TrimSpace(asString(entry["service"]))
+		if _, isExcluded := excluded[service]; isExcluded {
+			return fmt.Errorf("x-uds.network.expose references excluded service %q", service)
+		}
+	}
+	for _, raw := range pkg.Monitor {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		service := strings.TrimSpace(asString(entry["service"]))
+		if _, isExcluded := excluded[service]; isExcluded {
+			return fmt.Errorf("x-uds.monitor references excluded service %q", service)
+		}
+	}
+	return nil
 }
 
 func canonicalBuildMaps(project types.Project) (map[string]any, map[string]any, error) {
@@ -721,7 +857,7 @@ func parseServiceConfigs(raw []types.ServiceConfigObjConfig, aliases map[string]
 	return refs, nil
 }
 
-func parseDependsOn(raw types.DependsOnConfig, serviceAliases map[string]string) ([]model.Dependency, error) {
+func parseDependsOn(raw types.DependsOnConfig, serviceAliases map[string]string, excludedServices map[string]struct{}) ([]model.Dependency, error) {
 	if len(raw) == 0 {
 		return nil, nil
 	}
@@ -731,6 +867,9 @@ func parseDependsOn(raw types.DependsOnConfig, serviceAliases map[string]string)
 		resolved, ok := resolveAlias(serviceAliases, rawName)
 		if !ok {
 			return nil, fmt.Errorf("unknown service %q", rawName)
+		}
+		if _, excluded := excludedServices[resolved]; excluded {
+			continue
 		}
 		if _, exists := seen[resolved]; exists {
 			continue
@@ -853,9 +992,6 @@ func normalizeTopLevelConfigs(raw types.Configs) (map[string]model.Config, map[s
 		}
 		if _, exists := configs[normalized]; exists {
 			return nil, nil, fmt.Errorf("duplicate normalized top-level config name %q", normalized)
-		}
-		if bool(value.External) && strings.TrimSpace(value.Content) == "" {
-			return nil, nil, fmt.Errorf("external compose config %q is not supported", key)
 		}
 		configs[normalized] = model.Config{Name: normalized, External: bool(value.External), Content: value.Content}
 		registerAlias(aliases, key, normalized)

--- a/internal/compose/compatibility.go
+++ b/internal/compose/compatibility.go
@@ -49,8 +49,9 @@ var unsupportedServiceRemediation = map[string]string{
 	"sysctls":      "remove host kernel tuning from the application package",
 }
 
-func validateCompatibility(project types.Project, raw map[string]any) error {
+func validateCompatibility(project types.Project, raw map[string]any, excludedServices map[string]struct{}) error {
 	issues := []CompatibilityIssue{}
+	includedNetworks := map[string]struct{}{}
 	rawServices, _ := asMap(raw["services"])
 	serviceNames := make([]string, 0, len(project.Services))
 	for name := range project.Services {
@@ -59,6 +60,9 @@ func validateCompatibility(project types.Project, raw map[string]any) error {
 	sort.Strings(serviceNames)
 
 	for _, serviceName := range serviceNames {
+		if _, excluded := excludedServices[serviceName]; excluded {
+			continue
+		}
 		service := project.Services[serviceName]
 		path := "services." + serviceName
 		rawService, _ := asMap(rawServices[serviceName])
@@ -95,6 +99,7 @@ func validateCompatibility(project types.Project, raw map[string]any) error {
 			fmt.Fprintf(os.Stderr, "warning: service %q container_name %q ignored; Kubernetes resources use the Compose service name\n", serviceName, containerName)
 		}
 		for networkName, network := range service.Networks {
+			includedNetworks[networkName] = struct{}{}
 			if network == nil {
 				continue
 			}
@@ -129,6 +134,9 @@ func validateCompatibility(project types.Project, raw map[string]any) error {
 	}
 
 	for name, network := range project.Networks {
+		if _, used := includedNetworks[name]; !used {
+			continue
+		}
 		unsupportedDriver := network.Driver != "" && network.Driver != "bridge"
 		if unsupportedDriver || len(network.DriverOpts) > 0 || network.Internal || network.Attachable || len(network.Ipam.Config) > 0 || network.Ipam.Driver != "" {
 			issues = append(issues, CompatibilityIssue{

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -1,6 +1,7 @@
 package render_test
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -450,6 +451,217 @@ func TestLoadCanonicalRejectsUnsupportedTopLevelNetworkOptions(t *testing.T) {
 				t.Fatalf("expected unsupported network options error, got %v", err)
 			}
 		})
+	}
+}
+
+func TestLoadCanonicalExcludesOptionalDependencyAndPrunesResources(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    depends_on:
+      db:
+        condition: service_healthy
+        required: false
+    volumes:
+      - shared-data:/var/lib/shared
+    secrets:
+      - shared-password
+    configs:
+      - shared-config
+  db:
+    image: postgres:18
+    platform: wasi/wasm
+    user: "0"
+    networks: [development]
+    expose:
+      - "5432"
+    volumes:
+      - shared-data:/var/lib/shared
+      - db-data:/var/lib/postgresql/data
+    secrets:
+      - shared-password
+      - db-password
+    configs:
+      - shared-config
+      - db-schema
+volumes:
+  shared-data: {}
+  db-data: {}
+secrets:
+  shared-password:
+    file: ./shared-password.txt
+  db-password:
+    file: ./db-password.txt
+configs:
+  shared-config:
+    content: shared
+  db-schema:
+    external: true
+networks:
+  development:
+    driver: overlay
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	if len(app.Services) != 1 || app.Services[0].Name != "api" {
+		t.Fatalf("expected only api to remain, got %#v", app.Services)
+	}
+	if len(app.Services[0].DependsOn) != 0 {
+		t.Fatalf("expected dependency on excluded db to be removed, got %#v", app.Services[0].DependsOn)
+	}
+	if len(app.Volumes) != 1 || app.Volumes["shared-data"].Name != "shared-data" {
+		t.Fatalf("expected only shared volume to remain, got %#v", app.Volumes)
+	}
+	if len(app.Secrets) != 1 || app.Secrets["shared-password"].Name != "shared-password" {
+		t.Fatalf("expected only shared secret to remain, got %#v", app.Secrets)
+	}
+	if len(app.Configs) != 1 || app.Configs["shared-config"].Name != "shared-config" {
+		t.Fatalf("expected only shared config to remain, got %#v", app.Configs)
+	}
+
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+	for _, path := range []string{
+		"chart/templates/deployment-db.yaml",
+		"chart/templates/service-db.yaml",
+		"chart/templates/pvc-db-data.yaml",
+		"chart/templates/configmap-db-schema.yaml",
+		"chart/templates/secret-db-password.yaml",
+		"chart/templates/uds-exemption.yaml",
+	} {
+		if _, err := os.Stat(filepath.Join(outDir, path)); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be omitted, stat err = %v", path, err)
+		}
+	}
+	for _, path := range []string{
+		"chart/templates/pvc-shared-data.yaml",
+		"chart/templates/configmap-shared-config.yaml",
+		"chart/templates/secret-shared-password.yaml",
+	} {
+		if _, err := os.Stat(filepath.Join(outDir, path)); err != nil {
+			t.Fatalf("expected shared resource %s to remain: %v", path, err)
+		}
+	}
+	zarfConfig := readFile(t, filepath.Join(outDir, "zarf.yaml"))
+	if strings.Contains(zarfConfig, "postgres:18") || strings.Contains(zarfConfig, model.DependencyInitImage) {
+		t.Fatalf("did not expect excluded image or dependency init image\n%s", zarfConfig)
+	}
+}
+
+func TestLoadCanonicalKeepsServiceWhenAnyDependencyReferenceIsRequired(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    depends_on:
+      db:
+        condition: service_started
+        required: false
+  worker:
+    image: ghcr.io/acme/worker:1.0.0
+    depends_on:
+      db:
+        condition: service_started
+        required: true
+  db:
+    image: postgres:18
+    expose: ["5432"]
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	if len(app.Services) != 3 {
+		t.Fatalf("expected db to remain because one reference is required, got %#v", app.Services)
+	}
+	for _, service := range app.Services {
+		if service.Name == "db" {
+			return
+		}
+	}
+	t.Fatalf("expected db to remain, got %#v", app.Services)
+}
+
+func TestLoadCanonicalKeepsShortSyntaxDependencyRequired(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    depends_on: [db]
+  db:
+    image: postgres:18
+    expose: ["5432"]
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	if len(app.Services) != 2 {
+		t.Fatalf("expected short-syntax dependency to remain required, got %#v", app.Services)
+	}
+}
+
+func TestLoadCanonicalRejectsXUDSReferenceToExcludedService(t *testing.T) {
+	t.Parallel()
+
+	for _, extension := range []string{
+		"network:\n    expose:\n      - service: db",
+		"monitor:\n    - service: db",
+	} {
+		input := []byte(fmt.Sprintf(`name: demo
+x-uds:
+  %s
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    depends_on:
+      db:
+        required: false
+  db:
+    image: postgres:18
+`, extension))
+		_, err := compose.LoadCanonicalYAML(input)
+		if err == nil || !strings.Contains(err.Error(), `references excluded service "db"`) {
+			t.Fatalf("expected excluded service reference error, got %v", err)
+		}
+	}
+}
+
+func TestLoadCanonicalRejectsBuildContextFromExcludedService(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: demo
+services:
+  api:
+    build:
+      context: .
+      additional_contexts:
+        base: service:base
+    depends_on:
+      base:
+        required: false
+  base:
+    build:
+      context: ./base
+`)
+
+	_, err := compose.LoadCanonicalYAML(input)
+	if err == nil || !strings.Contains(err.Error(), `build references excluded service "base"`) {
+		t.Fatalf("expected excluded build context error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Description

  Closes #70. Based on spike implementation 7968a69.

  Excludes development-only services from generated Zarf packages when every `depends_on` reference to the service uses `required: false`.

  Docker Compose continues to start these dependencies during local development, while Compose Bridge omits them and their exclusive resources from the generated
  package. If any dependency reference uses `required: true`, the service remains included.

  ## Changes

  - Detect services referenced exclusively through `depends_on.required: false`.
  - Preserve unreferenced services and services with any required dependency reference.
  - Preserve short-syntax `depends_on` behavior as required.
  - Omit excluded workloads, Kubernetes Services, images, policy exemptions, and dependency waits.
  - Remove references to excluded services from included workloads.
  - Prune volumes, configs, and secrets used only by excluded services.
  - Preserve resources shared with included services.
  - Ignore unsupported service settings and networks used exclusively by excluded services.
  - Reject references to excluded services from:
    - `x-uds.network.expose`
    - `x-uds.monitor`
    - Build `additional_contexts`
  - Update tests and documentation for the new behavior.

  This PR replaces the spike’s `x-uds-exclude` extension with the `depends_on.required: false` behavior specified by the issue.

  Shared secrets remain package-owned in this PR. Externalizing secrets shared with excluded services is intentionally deferred to #71.

  ## Validation

  - `go test ./...`
  - `go test -race ./...`
  - `go vet ./...`
  - `go build ./...`
  - `git diff --check`
  - Built the translator image from the updated source.
  - Converted `examples/full` with Redis marked `required: false`.
  - Successfully ran `zarf dev lint` against the generated package.
  - Successfully rendered the generated package with `zarf dev inspect manifests`.
  - Compared generated output against the exact latest `main` commit.
  - Verified the excluded Redis service does not generate:
    - A Deployment
    - A Kubernetes Service
    - A PVC
    - A packaged image
    - A dependency init container
