### PR TITLE
feat(secrets): externalize runtime Compose secrets

### DIFF
--- a/docs/compose-support.md
+++ b/docs/compose-support.md
@@ -7,7 +7,7 @@
 | `image:`                                                         | Container image reference.                                                                                                                                                                                                                                                      |
 | `build:`                                                         | Preserved as a generated Buildx Bake definition. `zarf package create` builds the image and adds its OCI archive to the package.                                                                                                                                                |
 | Named `volumes:`                                                 | Converted to PersistentVolumeClaims (`1Gi`, `ReadWriteOnce` by default).                                                                                                                                                                                                        |
-| `secrets:`                                                       | Converted to Kubernetes Secrets.                                                                                                                                                                                                                                                |
+| `secrets:`                                                       | Delivered as read-only files. Secrets used only by packaged services become package-owned Kubernetes Secrets. Native external secrets and secrets shared with excluded services reference deployment-provided Kubernetes Secret names and keys.                                                                                               |
 | `configs:`                                                       | Converted to reloadable ConfigMaps. Must use inline `content:` (no external file references).                                                                                                                                                                                   |
 | `environment:`, `env_file:`                                      | Resolved by `docker compose config`, exposed as non-sensitive Zarf variables, and rendered into a reloadable ConfigMap consumed by the service through `envFrom`.                                                                                                               |
 | `depends_on:`                                                    | Required dependencies become init-container wait logic using `netcat` (busybox). A service referenced only through long-syntax dependencies with `required: false` is excluded as a development-only service. Included dependencies must declare a port.                                                                                       |
@@ -53,6 +53,27 @@ waits, policy exemptions, or other package content. Volumes, configs, and
 secrets used only by excluded services are pruned; resources shared with an
 included service remain. Explicit `x-uds.network.expose`, `x-uds.monitor`, and
 build `additional_contexts` entries must not reference an excluded service.
+
+## Runtime secrets
+
+Compose grants services access to secrets as read-only files, normally under
+`/run/secrets`. The generated chart preserves each secret's target file path.
+
+- A secret consumed only by included services is package-owned. Zarf prompts
+  for its sensitive value, and the chart creates the Kubernetes Secret.
+- A secret consumed only by excluded services is omitted.
+- A secret consumed by included and excluded services becomes package-external.
+- A native Compose `external: true` secret consumed by an included service is
+  also package-external.
+
+For each package-external Compose secret, the generated Zarf package declares
+`<SECRET>_SECRET_NAME` and `<SECRET>_SECRET_KEY` variables. The name has no
+default and must identify an existing Kubernetes Secret in the package
+namespace. The key defaults to the normalized Compose secret name. These
+variables are non-sensitive references and do not expose the secret value.
+
+Different Compose secrets can select different keys from the same Kubernetes
+Secret. Build secrets are unaffected by this runtime-secret behavior.
 
 ## Runtime configuration
 

--- a/docs/uds-package.md
+++ b/docs/uds-package.md
@@ -4,7 +4,7 @@ The bridge maps the [Compose Specification](https://compose-spec.io/) to Kuberne
 
 For services with `build:`, the bridge also writes `out/build.compose.yaml`. Zarf `onCreate` actions use Buildx Bake to build those services into OCI archives under `out/image-archives/`, and the component's `imageArchives` entries add them to the package.
 
-Secrets are rendered from chart values rather than baked into templates. Service environment values are exposed as non-sensitive Zarf variables and rendered into per-service ConfigMaps. Every package also exposes `ADDITIONAL_NETWORK_ALLOW` for deploy-time UDS network rules. The bridge writes `out/values/values.yaml` with `###ZARF_VAR_*###` placeholders for these deploy-time values, references it through `charts[].valuesFiles`, and retains their defaults, prompts, indentation, and sensitivity settings in the Zarf package's `variables:`.
+Package-owned secrets are rendered from chart values rather than baked into templates. Package-external secrets carry only non-sensitive Kubernetes Secret name and key variables; the chart neither includes their values nor creates their Secret objects. Service environment values are exposed as non-sensitive Zarf variables and rendered into per-service ConfigMaps. Every package also exposes `ADDITIONAL_NETWORK_ALLOW` for deploy-time UDS network rules. The bridge writes `out/values/values.yaml` with `###ZARF_VAR_*###` placeholders for these deploy-time values, references it through `charts[].valuesFiles`, and retains their defaults, prompts, indentation, and sensitivity settings in the Zarf package's `variables:`.
 
 ## Inferred behavior
 

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -146,6 +146,7 @@ func loadProject(project types.Project, raw map[string]any, excludedServices map
 	if err != nil {
 		return model.App{}, err
 	}
+	excludedSecretRefs := collectExcludedSecretRefs(project, secretAliases, excludedServices)
 	configs, configAliases, err := normalizeTopLevelConfigs(project.Configs)
 	if err != nil {
 		return model.App{}, err
@@ -265,6 +266,7 @@ func loadProject(project types.Project, raw map[string]any, excludedServices map
 		})
 	}
 
+	markBoundarySecretsExternal(services, secrets, excludedSecretRefs)
 	volumes, secrets, configs = retainReferencedResources(services, volumes, secrets, configs)
 	for name, config := range configs {
 		if config.External && strings.TrimSpace(config.Content) == "" {
@@ -283,6 +285,44 @@ func loadProject(project types.Project, raw map[string]any, excludedServices map
 		Configs:      configs,
 		BuildSecrets: buildSecrets,
 	}, nil
+}
+
+// collectExcludedSecretRefs records known Compose secrets consumed by services
+// omitted from the package. Invalid references on excluded services are ignored
+// because those services otherwise bypass bridge compatibility validation.
+func collectExcludedSecretRefs(project types.Project, aliases map[string]string, excludedServices map[string]struct{}) map[string]struct{} {
+	refs := map[string]struct{}{}
+	for serviceName, service := range project.Services {
+		if _, excluded := excludedServices[serviceName]; !excluded {
+			continue
+		}
+		for _, entry := range service.Secrets {
+			name, ok := resolveAlias(aliases, strings.TrimSpace(entry.Source))
+			if ok {
+				refs[name] = struct{}{}
+			}
+		}
+	}
+	return refs
+}
+
+// markBoundarySecretsExternal keeps local Compose secret files available to
+// excluded development dependencies while making packaged consumers reference
+// a Kubernetes Secret supplied by the deployment environment.
+func markBoundarySecretsExternal(services []model.Service, secrets map[string]model.Secret, excludedRefs map[string]struct{}) {
+	for _, service := range services {
+		for _, ref := range service.Secrets {
+			if _, crossesBoundary := excludedRefs[ref.Source]; !crossesBoundary {
+				continue
+			}
+			secret, exists := secrets[ref.Source]
+			if !exists {
+				continue
+			}
+			secret.External = true
+			secrets[ref.Source] = secret
+		}
+	}
 }
 
 func rejectExcludedBuildContexts(serviceName string, build map[string]any, excluded map[string]struct{}) error {

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -136,25 +136,30 @@ func WritePackage(root string, app model.App) error {
 		}
 	}
 
-	// Secrets are rendered by Helm from chart values so Zarf can substitute the
-	// sensitive value into the values file at deploy time (Zarf only templates
-	// chart valuesFiles, not arbitrary template files). secretValueKeys tracks the
-	// values keys used so the chart defaults and the Zarf values file stay in sync.
-	secretValueKeys := make([]string, 0, len(app.Secrets))
+	// Package-owned secrets are rendered by Helm from sensitive Zarf values.
+	// External secrets are not created by this chart; workloads reference an
+	// existing Kubernetes Secret selected through deploy-time name and key values.
 	for _, name := range sortedSecretNames(app.Secrets) {
 		secret := app.Secrets[name]
 		if secret.External {
 			continue
 		}
-		variableName := secretVariables[secret.Name]
+		variableName := secretVariables[secret.Name].Value
 		if err := writeSecretTemplate(filepath.Join(templatesDir, fmt.Sprintf("secret-%s.yaml", secret.Name)), app, secret, variableName); err != nil {
 			return err
 		}
-		secretValueKeys = append(secretValueKeys, variableName)
 	}
 
 	for _, svc := range app.Services {
-		deployment, err := buildDeployment(app.Package.Name, app.Package.Namespace, svc, servicePorts, preserveNetworkMembership)
+		deployment, err := buildDeployment(
+			app.Package.Name,
+			app.Package.Namespace,
+			svc,
+			servicePorts,
+			preserveNetworkMembership,
+			app.Secrets,
+			secretVariables,
+		)
 		if err != nil {
 			return err
 		}
@@ -183,7 +188,7 @@ func WritePackage(root string, app model.App) error {
 	if err := writeChartMetadata(filepath.Join(chartDir, "Chart.yaml"), app); err != nil {
 		return err
 	}
-	if err := writeChartValues(filepath.Join(chartDir, "values.yaml"), app, secretValueKeys, environmentVariables, false); err != nil {
+	if err := writeChartValues(filepath.Join(chartDir, "values.yaml"), app, secretVariables, environmentVariables, false); err != nil {
 		return err
 	}
 
@@ -191,7 +196,7 @@ func WritePackage(root string, app model.App) error {
 	if err := os.MkdirAll(filepath.Dir(valuesPath), 0o755); err != nil {
 		return fmt.Errorf("create directory %s: %w", filepath.Dir(valuesPath), err)
 	}
-	if err := writeChartValues(valuesPath, app, secretValueKeys, environmentVariables, true); err != nil {
+	if err := writeChartValues(valuesPath, app, secretVariables, environmentVariables, true); err != nil {
 		return err
 	}
 
@@ -458,7 +463,7 @@ func writeChartMetadata(path string, app model.App) error {
 func writeChartValues(
 	path string,
 	app model.App,
-	secretKeys []string,
+	secretVariables map[string]secretVariableNames,
 	environmentVariables map[string]map[string]string,
 	placeholder bool,
 ) error {
@@ -466,6 +471,7 @@ func writeChartValues(
 		AdditionalNetworkAllow: []any{},
 		Environment:            map[string]map[string]string{},
 		Secrets:                map[string]string{},
+		ExternalSecrets:        map[string]externalSecretValues{},
 	}
 	if placeholder {
 		values.AdditionalNetworkAllow = zarfNetworkAllowPlaceholder
@@ -486,11 +492,22 @@ func writeChartValues(
 		values.Environment[svc.Name] = serviceValues
 	}
 
-	for _, key := range secretKeys {
+	for _, name := range sortedSecretNames(app.Secrets) {
+		secret := app.Secrets[name]
+		variable := secretVariables[name]
+		if secret.External {
+			external := externalSecretValues{Key: secret.Name}
+			if placeholder {
+				external.Name = fmt.Sprintf("###ZARF_VAR_%s###", variable.SecretName)
+				external.Key = fmt.Sprintf("###ZARF_VAR_%s###", variable.SecretKey)
+			}
+			values.ExternalSecrets[variable.ValuesKey] = external
+			continue
+		}
 		if placeholder {
-			values.Secrets[key] = fmt.Sprintf("###ZARF_VAR_%s###", key)
+			values.Secrets[variable.Value] = fmt.Sprintf("###ZARF_VAR_%s###", variable.Value)
 		} else {
-			values.Secrets[key] = ""
+			values.Secrets[variable.Value] = ""
 		}
 	}
 
@@ -516,7 +533,7 @@ func writeChartValues(
 func writeZarfConfig(
 	path string,
 	app model.App,
-	secretVariables map[string]string,
+	secretVariables map[string]secretVariableNames,
 	environmentVariables map[string]map[string]string,
 	images []string,
 ) error {
@@ -527,8 +544,24 @@ func writeZarfConfig(
 		AutoIndent:  true,
 	}}
 	for _, secretName := range sortedSecretNames(app.Secrets) {
+		secret := app.Secrets[secretName]
+		variable := secretVariables[secretName]
+		if secret.External {
+			variables = append(variables,
+				zarfVariable{
+					Name:        variable.SecretName,
+					Description: fmt.Sprintf("Kubernetes Secret name for external compose secret %s", secretName),
+				},
+				zarfVariable{
+					Name:        variable.SecretKey,
+					Description: fmt.Sprintf("Key in the Kubernetes Secret for external compose secret %s", secretName),
+					Default:     stringPointer(secret.Name),
+				},
+			)
+			continue
+		}
 		variables = append(variables, zarfVariable{
-			Name:        secretVariables[secretName],
+			Name:        variable.Value,
 			Description: fmt.Sprintf("Value for compose secret %s", secretName),
 			Prompt:      true,
 			Sensitive:   true,
@@ -594,9 +627,17 @@ func writeZarfConfig(
 	return nil
 }
 
-func buildDeployment(appName string, namespace string, svc model.Service, servicePorts map[string]int, preserveNetworkMembership bool) (deploymentManifest, error) {
+func buildDeployment(
+	appName string,
+	namespace string,
+	svc model.Service,
+	servicePorts map[string]int,
+	preserveNetworkMembership bool,
+	secrets map[string]model.Secret,
+	secretVariables map[string]secretVariableNames,
+) (deploymentManifest, error) {
 	ports := svc.Ports
-	volumes, volumeMounts := buildVolumes(svc)
+	volumes, volumeMounts := buildVolumes(svc, secrets, secretVariables)
 	resources := buildResources(svc.Resources)
 	securityContext := buildSecurityContext(svc)
 	initContainers := buildDependencyInitContainers(svc, servicePorts)
@@ -1172,7 +1213,7 @@ func gatewayPortCandidate(port model.Port, requirePublished bool) bool {
 	return !requirePublished || port.Published
 }
 
-func buildVolumes(svc model.Service) ([]volumeSpec, []volumeMountSpec) {
+func buildVolumes(svc model.Service, secrets map[string]model.Secret, secretVariables map[string]secretVariableNames) ([]volumeSpec, []volumeMountSpec) {
 	volumes := make([]volumeSpec, 0, len(svc.Volumes)+len(svc.Secrets)+len(svc.Configs))
 	mounts := make([]volumeMountSpec, 0, len(svc.Volumes)+len(svc.Secrets)+len(svc.Configs))
 
@@ -1193,11 +1234,26 @@ func buildVolumes(svc model.Service) ([]volumeSpec, []volumeMountSpec) {
 
 	for _, ref := range svc.Secrets {
 		volumeName := sanitizeManifestName("secret-" + ref.Source)
+		secretName := ref.Source
+		secretKey := ref.Source
+		if secret, exists := secrets[ref.Source]; exists && secret.External {
+			variable := secretVariables[ref.Source]
+			secretName = fmt.Sprintf(
+				`{{ required "external compose secret %s requires a Kubernetes Secret name" .Values.externalSecrets.%s.name }}`,
+				secret.Name,
+				variable.ValuesKey,
+			)
+			secretKey = fmt.Sprintf(
+				`{{ required "external compose secret %s requires a Kubernetes Secret key" .Values.externalSecrets.%s.key }}`,
+				secret.Name,
+				variable.ValuesKey,
+			)
+		}
 		volumes = append(volumes, volumeSpec{
 			Name: volumeName,
 			Secret: &secretVolumeSource{
-				SecretName: ref.Source,
-				Items:      []keyToPath{{Key: ref.Source, Path: ref.Source}},
+				SecretName: secretName,
+				Items:      []keyToPath{{Key: secretKey, Path: ref.Source}},
 			},
 		})
 		mounts = append(mounts, volumeMountSpec{
@@ -1476,18 +1532,24 @@ func buildProbe(healthcheck *model.Healthcheck) *probe {
 
 func buildEnvironmentVariables(
 	app model.App,
-	secretVariables map[string]string,
+	secretVariables map[string]secretVariableNames,
 ) (map[string]map[string]string, error) {
 	usedVariables := map[string]string{
 		additionalNetworkAllowVariable: "reserved package variable",
 	}
 	for _, secretName := range sortedSecretNames(app.Secrets) {
-		if err := registerZarfVariable(
-			usedVariables,
-			secretVariables[secretName],
-			fmt.Sprintf("compose secret %q", secretName),
-		); err != nil {
-			return nil, err
+		variable := secretVariables[secretName]
+		for _, name := range []string{variable.Value, variable.SecretName, variable.SecretKey} {
+			if name == "" {
+				continue
+			}
+			if err := registerZarfVariable(
+				usedVariables,
+				name,
+				fmt.Sprintf("compose secret %q", secretName),
+			); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -1557,11 +1619,31 @@ func registerZarfVariable(used map[string]string, name, owner string) error {
 	return nil
 }
 
-func buildSecretVariables(secrets map[string]model.Secret) map[string]string {
-	used := map[string]struct{}{}
-	out := map[string]string{}
+type secretVariableNames struct {
+	ValuesKey  string
+	Value      string
+	SecretName string
+	SecretKey  string
+}
+
+func buildSecretVariables(secrets map[string]model.Secret) map[string]secretVariableNames {
+	usedValuesKeys := map[string]struct{}{}
+	usedVariables := map[string]struct{}{}
+	out := map[string]secretVariableNames{}
 	for _, name := range sortedSecretNames(secrets) {
-		out[name] = buildSecretVariableName(name, used)
+		valuesKey := buildSecretVariableName(name, usedValuesKeys)
+		if secrets[name].External {
+			out[name] = secretVariableNames{
+				ValuesKey:  valuesKey,
+				SecretName: buildSecretVariableName(valuesKey+"_SECRET_NAME", usedVariables),
+				SecretKey:  buildSecretVariableName(valuesKey+"_SECRET_KEY", usedVariables),
+			}
+			continue
+		}
+		out[name] = secretVariableNames{
+			ValuesKey: valuesKey,
+			Value:     buildSecretVariableName(valuesKey, usedVariables),
+		}
 	}
 	return out
 }
@@ -2079,7 +2161,13 @@ type chartMetadata struct {
 // chartValues is the values document written for both the chart defaults
 // (chart/values.yaml) and the Zarf-templated overrides (values/values.yaml).
 type chartValues struct {
-	AdditionalNetworkAllow any                          `yaml:"additionalNetworkAllow"`
-	Environment            map[string]map[string]string `yaml:"environment,omitempty"`
-	Secrets                map[string]string            `yaml:"secrets"`
+	AdditionalNetworkAllow any                             `yaml:"additionalNetworkAllow"`
+	Environment            map[string]map[string]string    `yaml:"environment,omitempty"`
+	Secrets                map[string]string               `yaml:"secrets,omitempty"`
+	ExternalSecrets        map[string]externalSecretValues `yaml:"externalSecrets,omitempty"`
+}
+
+type externalSecretValues struct {
+	Name string `yaml:"name"`
+	Key  string `yaml:"key"`
 }

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -2191,7 +2191,7 @@ type chartValues struct {
 	Environment            map[string]map[string]string    `yaml:"environment,omitempty"`
 	Secrets                map[string]string               `yaml:"secrets"`
 	ExternalSecrets        map[string]externalSecretValues `yaml:"externalSecrets,omitempty"`
-	UDS                    udsValues                    `yaml:"uds"`
+	UDS                    udsValues                       `yaml:"uds"`
 }
 
 type udsValues struct {

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -521,6 +521,9 @@ networks:
 	if len(app.Secrets) != 1 || app.Secrets["shared-password"].Name != "shared-password" {
 		t.Fatalf("expected only shared secret to remain, got %#v", app.Secrets)
 	}
+	if !app.Secrets["shared-password"].External {
+		t.Fatalf("expected secret shared with excluded db to become external, got %#v", app.Secrets)
+	}
 	if len(app.Configs) != 1 || app.Configs["shared-config"].Name != "shared-config" {
 		t.Fatalf("expected only shared config to remain, got %#v", app.Configs)
 	}
@@ -541,10 +544,12 @@ networks:
 			t.Fatalf("expected %s to be omitted, stat err = %v", path, err)
 		}
 	}
+	if _, err := os.Stat(filepath.Join(outDir, "chart", "templates", "secret-shared-password.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("expected external shared secret not to be created, stat err = %v", err)
+	}
 	for _, path := range []string{
 		"chart/templates/pvc-shared-data.yaml",
 		"chart/templates/configmap-shared-config.yaml",
-		"chart/templates/secret-shared-password.yaml",
 	} {
 		if _, err := os.Stat(filepath.Join(outDir, path)); err != nil {
 			t.Fatalf("expected shared resource %s to remain: %v", path, err)
@@ -553,6 +558,31 @@ networks:
 	zarfConfig := readFile(t, filepath.Join(outDir, "zarf.yaml"))
 	if strings.Contains(zarfConfig, "postgres:18") || strings.Contains(zarfConfig, model.DependencyInitImage) {
 		t.Fatalf("did not expect excluded image or dependency init image\n%s", zarfConfig)
+	}
+	for _, want := range []string{
+		"name: SHARED_PASSWORD_SECRET_NAME",
+		"name: SHARED_PASSWORD_SECRET_KEY",
+		"default: shared-password",
+	} {
+		if !strings.Contains(zarfConfig, want) {
+			t.Fatalf("expected external secret variable %q\n%s", want, zarfConfig)
+		}
+	}
+	if strings.Contains(zarfConfig, "sensitive: true") || strings.Contains(zarfConfig, "prompt: true") {
+		t.Fatalf("external secret references must not prompt or be sensitive\n%s", zarfConfig)
+	}
+
+	deployment := readFile(t, filepath.Join(outDir, "chart", "templates", "deployment-api.yaml"))
+	for _, want := range []string{
+		"external compose secret shared-password requires a Kubernetes Secret name",
+		".Values.externalSecrets.SHARED_PASSWORD.name",
+		".Values.externalSecrets.SHARED_PASSWORD.key",
+		"mountPath: /run/secrets/shared-password",
+		"subPath: shared-password",
+	} {
+		if !strings.Contains(deployment, want) {
+			t.Fatalf("expected deployment to contain %q\n%s", want, deployment)
+		}
 	}
 }
 
@@ -2479,10 +2509,108 @@ secrets:
 		"valuesFiles:",
 		"values/values.yaml",
 		"name: API_KEY",
+		"prompt: true",
 		"sensitive: true",
 	} {
 		if !strings.Contains(zarfConfig, want) {
 			t.Fatalf("expected zarf.yaml to contain %q\n%s", want, zarfConfig)
+		}
+	}
+
+	deployment := readFile(t, filepath.Join(outDir, "chart", "templates", "deployment-api.yaml"))
+	for _, want := range []string{
+		"name: secret-api-key",
+		"secretName: api-key",
+		"key: api-key",
+		"path: api-key",
+		"mountPath: /run/secrets/api_key",
+		"subPath: api-key",
+	} {
+		if !strings.Contains(deployment, want) {
+			t.Fatalf("expected package-owned secret file mount %q\n%s", want, deployment)
+		}
+	}
+	if strings.Contains(deployment, "mountPath: /run/secrets\n") {
+		t.Fatalf("secret must not replace the service-account parent directory\n%s", deployment)
+	}
+}
+
+func TestWritePackageNativeExternalSecretUsesNameAndKeyVariables(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: shop
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    secrets:
+      - source: operator-credential
+        target: /etc/shop/database-password
+secrets:
+  operator-credential:
+    external: true
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	if !app.Secrets["operator-credential"].External {
+		t.Fatalf("expected native external Compose secret to remain external, got %#v", app.Secrets)
+	}
+
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "chart", "templates", "secret-operator-credential.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("expected no chart-owned Secret for native external secret, stat err = %v", err)
+	}
+
+	chartValues := readFile(t, filepath.Join(outDir, "chart", "values.yaml"))
+	for _, want := range []string{
+		"externalSecrets:",
+		"OPERATOR_CREDENTIAL:",
+		"name: \"\"",
+		"key: operator-credential",
+	} {
+		if !strings.Contains(chartValues, want) {
+			t.Fatalf("expected chart values to contain %q\n%s", want, chartValues)
+		}
+	}
+
+	zarfValues := readFile(t, filepath.Join(outDir, "values", "values.yaml"))
+	for _, want := range []string{
+		"###ZARF_VAR_OPERATOR_CREDENTIAL_SECRET_NAME###",
+		"###ZARF_VAR_OPERATOR_CREDENTIAL_SECRET_KEY###",
+	} {
+		if !strings.Contains(zarfValues, want) {
+			t.Fatalf("expected Zarf values to contain %q\n%s", want, zarfValues)
+		}
+	}
+
+	zarfConfig := readFile(t, filepath.Join(outDir, "zarf.yaml"))
+	for _, want := range []string{
+		"name: OPERATOR_CREDENTIAL_SECRET_NAME",
+		"name: OPERATOR_CREDENTIAL_SECRET_KEY",
+		"default: operator-credential",
+	} {
+		if !strings.Contains(zarfConfig, want) {
+			t.Fatalf("expected external secret variable %q\n%s", want, zarfConfig)
+		}
+	}
+	if strings.Contains(zarfConfig, "sensitive: true") || strings.Contains(zarfConfig, "prompt: true") {
+		t.Fatalf("external secret references must not prompt or be sensitive\n%s", zarfConfig)
+	}
+
+	deployment := readFile(t, filepath.Join(outDir, "chart", "templates", "deployment-api.yaml"))
+	for _, want := range []string{
+		".Values.externalSecrets.OPERATOR_CREDENTIAL.name",
+		".Values.externalSecrets.OPERATOR_CREDENTIAL.key",
+		"mountPath: /etc/shop/database-password",
+		"subPath: operator-credential",
+	} {
+		if !strings.Contains(deployment, want) {
+			t.Fatalf("expected custom external secret file mount %q\n%s", want, deployment)
 		}
 	}
 }
@@ -2643,6 +2771,20 @@ func TestWritePackageRejectsInvalidEnvironmentExternalization(t *testing.T) {
 				Secrets: map[string]model.Secret{"api-token": {Name: "api-token"}},
 			},
 			wantErr: `generates Zarf variable "API_TOKEN", which conflicts with compose secret "api-token"`,
+		},
+		{
+			name: "external secret reference variable collision",
+			app: model.App{
+				Package: model.Package{Name: "shop", Namespace: "shop", Version: "0.1.0"},
+				Services: []model.Service{{
+					Name: "api-token-secret", Image: "ghcr.io/acme/api:1.0.0",
+					Env: []model.EnvVar{{Name: "NAME", Value: "not-a-secret-reference"}},
+				}},
+				Secrets: map[string]model.Secret{
+					"api-token": {Name: "api-token", External: true},
+				},
+			},
+			wantErr: `generates Zarf variable "API_TOKEN_SECRET_NAME", which conflicts with compose secret "api-token"`,
 		},
 		{
 			name: "cross-service variable collision",


### PR DESCRIPTION
## Description

  Closes #71. Based on spike implementations f5553cb and c19da9d.

  Allows packaged services to consume Kubernetes Secrets created outside the generated package, such as credentials managed by an operator or UDS Bundle.

  A runtime Compose secret becomes package-external when it declares `external: true` or is shared by an included service and a development service excluded through
  `depends_on.required: false`.

  Package-owned secrets continue to use sensitive Zarf variables and chart-generated Kubernetes Secrets.

  ## Changes

  - Detect secrets shared by included and excluded services.
  - Preserve native Compose `external: true` secrets as package-external.
  - Generate two non-sensitive Zarf variables for each external secret:
    - `<SECRET>_SECRET_NAME`
    - `<SECRET>_SECRET_KEY`
  - Require the Kubernetes Secret name at deployment.
  - Default the Kubernetes Secret key to the normalized Compose secret name.
  - Omit chart-generated Secret objects for external secrets.
  - Template external Secret names and keys into workload volumes.
  - Preserve each Compose secret as an individual read-only file at its configured target path.
  - Preserve existing sensitive variable behavior for package-owned secrets.
  - Reject collisions between external secret reference variables, environment variables, and reserved package variables.
  - Update tests and documentation for runtime secret behavior.

  This PR is intentionally scoped to runtime secret externalization and builds on the development-service exclusion behavior introduced by #70.

  ## Validation

  - `go test ./...`
  - `go test -race ./...`
  - `go vet ./...`
  - `go build ./...`
  - `git diff --check`
  - Built the translator image from the updated source.
  - Converted `examples/full` with Redis marked as an optional development dependency sharing `app_secret` with the packaged server.
  - Successfully ran `zarf dev lint` against the generated package.
  - Successfully rendered the generated package with `zarf dev inspect manifests`.
  - Verified an operator-provided Kubernetes Secret name and key render into the Deployment.
  - Verified the Secret key defaults to the normalized Compose secret name when not overridden.
  - Compared generated output against the exact merged `main` implementation.
  - Verified external secrets do not generate Kubernetes Secret manifests or sensitive Zarf value variables.