### PR TITLE
feat(sso): add configurable package domain

### DIFF
--- a/docs/compose-support.md
+++ b/docs/compose-support.md
@@ -60,7 +60,13 @@ Every resolved service environment value becomes a non-sensitive Zarf variable n
 
 The bridge renders one `<service>-environment` ConfigMap for each service with environment values and attaches it to that service through `envFrom`. Empty environment ConfigMaps are omitted. Environment and Compose configuration ConfigMaps carry the `uds.dev/pod-reload: "true"` label so UDS can restart dependent Pods when their data changes. Direct Helm deployments do not provide that UDS reload behavior.
 
-ConfigMaps do not protect sensitive data; use Compose `secrets:` for credentials and other confidential values. Environment names must use the portable `[A-Za-z_][A-Za-z0-9_]*` form. Generated Zarf variable names must also be unique across all services, secrets, and reserved package variables such as `ADDITIONAL_NETWORK_ALLOW`; conversion fails rather than emitting an ambiguous package when names collide.
+ConfigMaps do not protect sensitive data; use Compose `secrets:` for credentials and other confidential values. Environment names must use the portable `[A-Za-z_][A-Za-z0-9_]*` form. Generated Zarf variable names must also be unique across all services, secrets, and automatic package variables such as `DOMAIN` and `ADDITIONAL_NETWORK_ALLOW`; conversion fails rather than emitting an ambiguous package when names collide.
+
+## Package domain
+
+Every generated package exposes the non-sensitive Zarf variable `DOMAIN`, defaulting to `uds.dev`. The value is available to the generated Helm chart as `uds.domain` and configures domain-aware endpoints inferred by the bridge, including inferred SSO redirect URIs. An `x-uds.sso` redirect URI supplied by the Compose author remains literal, including any Helm expression it contains.
+
+`DOMAIN` is package configuration, not container configuration. The bridge does not inject it into application containers or give special meaning to a Compose environment variable named `DOMAIN`. Applications that need their public origin must continue to declare the setting expected by the image, such as `PUBLIC_URL`, `ROOT_URL`, or `APP_ORIGIN`, in Compose.
 
 ## Deploy-time network access
 

--- a/docs/uds-package.md
+++ b/docs/uds-package.md
@@ -4,13 +4,13 @@ The bridge maps the [Compose Specification](https://compose-spec.io/) to Kuberne
 
 For services with `build:`, the bridge also writes `out/build.compose.yaml`. Zarf `onCreate` actions use Buildx Bake to build those services into OCI archives under `out/image-archives/`, and the component's `imageArchives` entries add them to the package.
 
-Secrets are rendered from chart values rather than baked into templates. Service environment values are exposed as non-sensitive Zarf variables and rendered into per-service ConfigMaps. Every package also exposes `ADDITIONAL_NETWORK_ALLOW` for deploy-time UDS network rules. The bridge writes `out/values/values.yaml` with `###ZARF_VAR_*###` placeholders for these deploy-time values, references it through `charts[].valuesFiles`, and retains their defaults, prompts, indentation, and sensitivity settings in the Zarf package's `variables:`.
+Secrets are rendered from chart values rather than baked into templates. Service environment values are exposed as non-sensitive Zarf variables and rendered into per-service ConfigMaps. Every package also exposes `DOMAIN` for generated endpoints and `ADDITIONAL_NETWORK_ALLOW` for deploy-time UDS network rules. The bridge writes `out/values/values.yaml` with `###ZARF_VAR_*###` placeholders for these deploy-time values, references it through `charts[].valuesFiles`, and retains their defaults, prompts, indentation, and sensitivity settings in the Zarf package's `variables:`.
 
 ## Inferred behavior
 
 - **Expose:** Services with published `ports:` are exposed on the tenant gateway. For multi-port services, the bridge prefers Compose `app_protocol` or `name` values indicating web traffic, then falls back to the first published port.
 - **Network allow:** Intra-namespace ingress and egress rules are always included so services in the namespace can communicate. Static `x-uds.network.allow` entries follow inferred rules, and deploy-time `ADDITIONAL_NETWORK_ALLOW` entries are appended last.
-- **SSO:** A Keycloak client is generated for the first exposed service and omitted when no services are exposed.
+- **SSO:** A Keycloak client is generated for the first exposed service and omitted when no services are exposed. Inferred redirect URIs use the package's deploy-time `DOMAIN`, which defaults to `uds.dev`.
 - **Policy exemptions:** Services requiring UDS policy exceptions produce `chart/templates/uds-exemption.yaml`.
 - **Monitoring:** Monitoring is opt-in through `x-uds.monitor[]`.
 - **Development dependencies:** Services referenced only by `depends_on` entries with `required: false` are omitted along with resources used exclusively by them.
@@ -42,7 +42,7 @@ x-uds:
 
 ### Extension notes
 
-- **`x-uds.sso`:** Missing `clientId`, `name`, `redirectUris`, and `enableAuthserviceSelector` fields are inferred. An explicitly empty list disables inferred SSO.
+- **`x-uds.sso`:** Missing `clientId`, `name`, `redirectUris`, and `enableAuthserviceSelector` fields are inferred. Inferred redirect URIs use `DOMAIN`; explicitly supplied redirect URIs remain unchanged and in declaration order. An explicitly empty list disables inferred SSO without removing `DOMAIN` from the package interface.
 - **`x-uds.monitor[]`:** Entries may be raw UDS `spec.monitor[]` items or use the bridge-only `service` key to infer labels and port metadata. Set `portName` or `targetPort` for multi-port services.
 - **`x-uds.caBundle.configMap`:** This customizes the namespace trust-bundle ConfigMap. Trust bundle contents are configured separately in UDS Core.
 

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -40,6 +40,10 @@ const (
 	additionalNetworkAllowVariable    = "ADDITIONAL_NETWORK_ALLOW"
 	additionalNetworkAllowPlaceholder = "__HELM_ADDITIONAL_NETWORK_ALLOW__"
 	zarfNetworkAllowPlaceholder       = "__ZARF_ADDITIONAL_NETWORK_ALLOW__"
+	domainVariable                    = "DOMAIN"
+	defaultDomain                     = "uds.dev"
+	helmDomainValue                   = "{{ .Values.uds.domain }}"
+	zarfDomainPlaceholder             = "__ZARF_DOMAIN__"
 )
 
 func WritePackage(root string, app model.App) error {
@@ -466,9 +470,11 @@ func writeChartValues(
 		AdditionalNetworkAllow: []any{},
 		Environment:            map[string]map[string]string{},
 		Secrets:                map[string]string{},
+		UDS:                    udsValues{Domain: defaultDomain},
 	}
 	if placeholder {
 		values.AdditionalNetworkAllow = zarfNetworkAllowPlaceholder
+		values.UDS.Domain = zarfDomainPlaceholder
 	}
 
 	for _, svc := range app.Services {
@@ -506,6 +512,14 @@ func writeChartValues(
 		if rendered == string(marshaled) {
 			return fmt.Errorf("render additional network allow Zarf variable in %s: placeholder not found", path)
 		}
+
+		domainPlaceholderLine := "    domain: " + zarfDomainPlaceholder
+		domainVariableLine := "    domain: \"###ZARF_VAR_" + domainVariable + "###\""
+		withDomain := strings.Replace(rendered, domainPlaceholderLine, domainVariableLine, 1)
+		if withDomain == rendered {
+			return fmt.Errorf("render domain Zarf variable in %s: placeholder not found", path)
+		}
+		rendered = withDomain
 	}
 	if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil {
 		return fmt.Errorf("write file %s: %w", path, err)
@@ -520,12 +534,19 @@ func writeZarfConfig(
 	environmentVariables map[string]map[string]string,
 	images []string,
 ) error {
-	variables := []zarfVariable{{
-		Name:        additionalNetworkAllowVariable,
-		Description: "Additional UDS network allow rules (YAML array)",
-		Default:     stringPointer("[]"),
-		AutoIndent:  true,
-	}}
+	variables := []zarfVariable{
+		{
+			Name:        domainVariable,
+			Description: "The domain for accessing endpoints",
+			Default:     stringPointer(defaultDomain),
+		},
+		{
+			Name:        additionalNetworkAllowVariable,
+			Description: "Additional UDS network allow rules (YAML array)",
+			Default:     stringPointer("[]"),
+			AutoIndent:  true,
+		},
+	}
 	for _, secretName := range sortedSecretNames(app.Secrets) {
 		variables = append(variables, zarfVariable{
 			Name:        secretVariables[secretName],
@@ -1080,7 +1101,7 @@ func buildInferredSSO(app model.App) []any {
 			"clientId": app.Package.Name,
 			"name":     titleCase(app.Package.Name),
 			"redirectUris": []any{
-				fmt.Sprintf("https://%s.uds.dev/*", host),
+				inferredRedirectURI(host),
 			},
 			"enableAuthserviceSelector": map[string]string{
 				"app.kubernetes.io/name": service,
@@ -1104,7 +1125,7 @@ func enrichSSOEntries(app model.App) []any {
 		setDefault(item, "name", titleCase(app.Package.Name))
 		if host != "" {
 			setDefault(item, "redirectUris", []any{
-				fmt.Sprintf("https://%s.uds.dev/*", host),
+				inferredRedirectURI(host),
 			})
 		}
 		if service != "" {
@@ -1115,6 +1136,10 @@ func enrichSSOEntries(app model.App) []any {
 		enriched = append(enriched, item)
 	}
 	return enriched
+}
+
+func inferredRedirectURI(host string) string {
+	return fmt.Sprintf("https://%s.%s/*", host, helmDomainValue)
 }
 
 // findPrimaryExposedService determines the primary host and service name from expose rules.
@@ -1479,7 +1504,8 @@ func buildEnvironmentVariables(
 	secretVariables map[string]string,
 ) (map[string]map[string]string, error) {
 	usedVariables := map[string]string{
-		additionalNetworkAllowVariable: "reserved package variable",
+		additionalNetworkAllowVariable: fmt.Sprintf("automatic package variable %q", additionalNetworkAllowVariable),
+		domainVariable:                 fmt.Sprintf("automatic package variable %q", domainVariable),
 	}
 	for _, secretName := range sortedSecretNames(app.Secrets) {
 		if err := registerZarfVariable(
@@ -1558,24 +1584,11 @@ func registerZarfVariable(used map[string]string, name, owner string) error {
 }
 
 func buildSecretVariables(secrets map[string]model.Secret) map[string]string {
-	used := map[string]struct{}{}
 	out := map[string]string{}
 	for _, name := range sortedSecretNames(secrets) {
-		out[name] = buildSecretVariableName(name, used)
+		out[name] = normalizeZarfVariableName(name)
 	}
 	return out
-}
-
-func buildSecretVariableName(secretName string, used map[string]struct{}) string {
-	base := normalizeZarfVariableName(secretName)
-	candidate := base
-	for i := 2; ; i++ {
-		if _, exists := used[candidate]; !exists {
-			used[candidate] = struct{}{}
-			return candidate
-		}
-		candidate = fmt.Sprintf("%s_%d", base, i)
-	}
 }
 
 func normalizeZarfVariableName(raw string) string {
@@ -2082,4 +2095,9 @@ type chartValues struct {
 	AdditionalNetworkAllow any                          `yaml:"additionalNetworkAllow"`
 	Environment            map[string]map[string]string `yaml:"environment,omitempty"`
 	Secrets                map[string]string            `yaml:"secrets"`
+	UDS                    udsValues                    `yaml:"uds"`
+}
+
+type udsValues struct {
+	Domain string `yaml:"domain"`
 }

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -1032,6 +1032,91 @@ services:
 	}
 }
 
+func TestWritePackageAddsDomainPackageInterface(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: worker
+x-uds:
+  sso: []
+services:
+  worker:
+    image: ghcr.io/acme/worker:1.0.0
+    environment:
+      DOMAIN: internal.example
+    secrets:
+      - api_key
+secrets:
+  api_key:
+    file: ./api_key.txt
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	chartValues := readYAMLMap(t, filepath.Join(outDir, "chart", "values.yaml"))
+	udsValues := mustMap(t, chartValues["uds"])
+	if got := udsValues["domain"]; got != "uds.dev" {
+		t.Fatalf("expected default UDS domain, got %#v", got)
+	}
+	workerEnvironment := mustMap(t, mustMap(t, chartValues["environment"])["worker"])
+	if got := workerEnvironment["DOMAIN"]; got != "internal.example" {
+		t.Fatalf("expected Compose DOMAIN environment value to remain ordinary configuration, got %#v", got)
+	}
+	if _, ok := chartValues["additionalNetworkAllow"].([]any); !ok {
+		t.Fatalf("expected additional network allow values to coexist with uds.domain, got %#v", chartValues)
+	}
+	if _, ok := mustMap(t, chartValues["secrets"])["API_KEY"]; !ok {
+		t.Fatalf("expected secret values to coexist with uds.domain, got %#v", chartValues)
+	}
+
+	zarfValues := readFile(t, filepath.Join(outDir, "values", "values.yaml"))
+	for _, want := range []string{
+		"uds:\n    domain: \"###ZARF_VAR_DOMAIN###\"",
+		"###ZARF_VAR_WORKER_DOMAIN###",
+		"###ZARF_VAR_API_KEY###",
+		"###ZARF_VAR_ADDITIONAL_NETWORK_ALLOW###",
+	} {
+		if !strings.Contains(zarfValues, want) {
+			t.Fatalf("expected Zarf values to contain %q\n%s", want, zarfValues)
+		}
+	}
+
+	zarfConfig := readYAMLMap(t, filepath.Join(outDir, "zarf.yaml"))
+	variables, ok := zarfConfig["variables"].([]any)
+	if !ok {
+		t.Fatalf("expected Zarf variables, got %#v", zarfConfig["variables"])
+	}
+	variablesByName := map[string]map[string]any{}
+	for _, raw := range variables {
+		variable := mustMap(t, raw)
+		variablesByName[variable["name"].(string)] = variable
+	}
+	domain := variablesByName["DOMAIN"]
+	if domain == nil || domain["default"] != "uds.dev" || domain["description"] != "The domain for accessing endpoints" {
+		t.Fatalf("expected non-sensitive DOMAIN package variable, got %#v", domain)
+	}
+	if _, exists := domain["sensitive"]; exists {
+		t.Fatalf("DOMAIN must not be sensitive, got %#v", domain)
+	}
+	if _, exists := domain["prompt"]; exists {
+		t.Fatalf("DOMAIN must not prompt, got %#v", domain)
+	}
+	if variablesByName["WORKER_DOMAIN"] == nil || variablesByName["ADDITIONAL_NETWORK_ALLOW"] == nil || variablesByName["API_KEY"] == nil {
+		t.Fatalf("expected automatic, environment, and secret variables to coexist, got %#v", variablesByName)
+	}
+
+	udsPackage := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
+	if strings.Contains(udsPackage, "clientId:") {
+		t.Fatalf("explicitly empty SSO must remain disabled\n%s", udsPackage)
+	}
+}
+
 func TestWritePackageWithConfigAndExpose(t *testing.T) {
 	t.Parallel()
 
@@ -1587,7 +1672,7 @@ services:
 	for _, want := range []string{
 		"clientId: myapp",
 		"name: Myapp",
-		"https://web.uds.dev/*",
+		"https://web.{{ .Values.uds.domain }}/*",
 		"enableAuthserviceSelector",
 		"app.kubernetes.io/name: web",
 	} {
@@ -1676,8 +1761,59 @@ services:
 	if !strings.Contains(udsPackage, "name: Myapp") {
 		t.Fatalf("expected inferred name\n%s", udsPackage)
 	}
-	if !strings.Contains(udsPackage, "https://web.uds.dev/*") {
+	if !strings.Contains(udsPackage, "https://web.{{ .Values.uds.domain }}/*") {
 		t.Fatalf("expected inferred redirectUris\n%s", udsPackage)
+	}
+}
+
+func TestSSOExplicitRedirectURIsRemainLiteralAndOrdered(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: myapp
+x-uds:
+  sso:
+    - redirectUris:
+        - https://first.example/callback
+        - "https://custom.{{ .Values.uds.domain }}/callback"
+        - https://last.uds.dev/callback
+services:
+  web:
+    image: nginx:latest
+    ports:
+      - mode: ingress
+        target: 8080
+        published: "8080"
+        protocol: tcp
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	udsPackage := readFile(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
+	redirects := []string{
+		"https://first.example/callback",
+		"https://custom.{{ .Values.uds.domain }}/callback",
+		"https://last.uds.dev/callback",
+	}
+	previous := -1
+	for _, redirect := range redirects {
+		index := strings.Index(udsPackage, redirect)
+		if index < 0 {
+			t.Fatalf("expected explicit redirect URI %q to remain unchanged\n%s", redirect, udsPackage)
+		}
+		if index <= previous {
+			t.Fatalf("expected explicit redirect URI declaration order to be preserved\n%s", udsPackage)
+		}
+		previous = index
+	}
+	if strings.Contains(udsPackage, "https://web.{{ .Values.uds.domain }}/*") {
+		t.Fatalf("did not expect inferred redirect URI when redirectUris is supplied\n%s", udsPackage)
 	}
 }
 
@@ -2645,6 +2781,18 @@ func TestWritePackageRejectsInvalidEnvironmentExternalization(t *testing.T) {
 			wantErr: `generates Zarf variable "API_TOKEN", which conflicts with compose secret "api-token"`,
 		},
 		{
+			name: "normalized secret variable collision",
+			app: model.App{
+				Package:  model.Package{Name: "shop", Namespace: "shop", Version: "0.1.0"},
+				Services: []model.Service{{Name: "api", Image: "ghcr.io/acme/api:1.0.0"}},
+				Secrets: map[string]model.Secret{
+					"api-token": {Name: "api-token"},
+					"api_token": {Name: "api_token"},
+				},
+			},
+			wantErr: `compose secret "api_token" generates Zarf variable "API_TOKEN", which conflicts with compose secret "api-token"`,
+		},
+		{
 			name: "cross-service variable collision",
 			app: model.App{
 				Package: model.Package{Name: "shop", Namespace: "shop", Version: "0.1.0"},
@@ -2670,7 +2818,7 @@ func TestWritePackageRejectsInvalidEnvironmentExternalization(t *testing.T) {
 					Env: []model.EnvVar{{Name: "NETWORK_ALLOW", Value: "custom"}},
 				}},
 			},
-			wantErr: `generates Zarf variable "ADDITIONAL_NETWORK_ALLOW", which conflicts with reserved package variable`,
+			wantErr: `generates Zarf variable "ADDITIONAL_NETWORK_ALLOW", which conflicts with automatic package variable "ADDITIONAL_NETWORK_ALLOW"`,
 		},
 		{
 			name: "reserved secret variable collision",
@@ -2681,7 +2829,18 @@ func TestWritePackageRejectsInvalidEnvironmentExternalization(t *testing.T) {
 					"additional-network-allow": {Name: "additional-network-allow"},
 				},
 			},
-			wantErr: `compose secret "additional-network-allow" generates Zarf variable "ADDITIONAL_NETWORK_ALLOW", which conflicts with reserved package variable`,
+			wantErr: `compose secret "additional-network-allow" generates Zarf variable "ADDITIONAL_NETWORK_ALLOW", which conflicts with automatic package variable "ADDITIONAL_NETWORK_ALLOW"`,
+		},
+		{
+			name: "domain secret variable collision",
+			app: model.App{
+				Package:  model.Package{Name: "shop", Namespace: "shop", Version: "0.1.0"},
+				Services: []model.Service{{Name: "api", Image: "ghcr.io/acme/api:1.0.0"}},
+				Secrets: map[string]model.Secret{
+					"domain": {Name: "domain"},
+				},
+			},
+			wantErr: `compose secret "domain" generates Zarf variable "DOMAIN", which conflicts with automatic package variable "DOMAIN"`,
 		},
 		{
 			name: "compose config map collision",


### PR DESCRIPTION
  ## Summary

  - add a non-sensitive `DOMAIN` Zarf variable to every generated package, defaulting to `uds.dev`
  - expose the domain through `uds.domain` in the chart defaults and Zarf values file
  - use `{{ .Values.uds.domain }}` for fully inferred SSO redirects and `x-uds.sso` entries without `redirectUris`
  - preserve explicit redirect URIs, including Helm expressions and declaration order
  - keep `x-uds.sso: []` behavior while retaining the `DOMAIN` package interface
  - keep package-level `DOMAIN` separate from container environment configuration
  - reject normalized Zarf variable collisions with deterministic errors identifying both owners
  - document package-domain behavior and container configuration boundaries

  ## Validation

  - `go test ./...`
  - `go test -race ./...`
  - `go vet ./...`
  - `go build ./...`
  - `git diff --check`
  - generated and compared the full example against the current tip of `main`
  - ran `zarf dev lint` against the generated package
  - rendered manifests with `DOMAIN=apps.example.mil` and verified the inferred redirect URI

  Closes #81