### PR TITLE
fix(config): allow Kubernetes-compatible environment names

### DIFF
--- a/docs/compose-support.md
+++ b/docs/compose-support.md
@@ -81,7 +81,7 @@ Every resolved service environment value becomes a non-sensitive Zarf variable n
 
 The bridge renders one `<service>-environment` ConfigMap for each service with environment values and attaches it to that service through `envFrom`. Empty environment ConfigMaps are omitted. Environment and Compose configuration ConfigMaps carry the `uds.dev/pod-reload: "true"` label so UDS can restart dependent Pods when their data changes. Direct Helm deployments do not provide that UDS reload behavior.
 
-ConfigMaps do not protect sensitive data; use Compose `secrets:` for credentials and other confidential values. Environment names must use the portable `[A-Za-z_][A-Za-z0-9_]*` form. Generated Zarf variable names must also be unique across all services, secrets, and automatic package variables such as `DOMAIN` and `ADDITIONAL_NETWORK_ALLOW`; conversion fails rather than emitting an ambiguous package when names collide.
+ConfigMaps do not protect sensitive data; use Compose `secrets:` for credentials and other confidential values. Environment names must use the Kubernetes-compatible `[-._a-zA-Z][-._a-zA-Z0-9]*` form; dots and hyphens are supported. Generated Zarf variable names must also be unique across all services, secrets, and automatic package variables such as `DOMAIN` and `ADDITIONAL_NETWORK_ALLOW`; conversion fails rather than emitting an ambiguous package when names collide.
 
 ## Package domain
 

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -1604,12 +1604,12 @@ func buildEnvironmentVariables(
 
 		serviceVariables := map[string]string{}
 		for _, item := range svc.Env {
-			if !portableEnvironmentName.MatchString(item.Name) {
+			if !kubernetesEnvironmentName.MatchString(item.Name) {
 				return nil, fmt.Errorf(
 					"invalid environment variable %q on service %q: names used with generated envFrom ConfigMaps must match %s",
 					item.Name,
 					svc.Name,
-					portableEnvironmentName.String(),
+					kubernetesEnvironmentName.String(),
 				)
 			}
 			variableName := normalizeZarfVariableName(svc.Name + "_" + item.Name)
@@ -1852,7 +1852,7 @@ var repeatedPortNameHyphens = regexp.MustCompile(`-+`)
 var portNameLetter = regexp.MustCompile(`[a-z]`)
 var invalidZarfVariableRunes = regexp.MustCompile(`[^A-Z0-9_]+`)
 var validZarfVariableName = regexp.MustCompile(`^[A-Z0-9_]+$`)
-var portableEnvironmentName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+var kubernetesEnvironmentName = regexp.MustCompile(`^[-._a-zA-Z][-._a-zA-Z0-9]*$`)
 
 func sanitizeManifestName(raw string) string {
 	name := strings.ToLower(strings.TrimSpace(raw))

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -2863,6 +2863,59 @@ services:
 	}
 }
 
+func TestWritePackageExternalizesKubernetesEnvironmentNames(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: elk
+services:
+  elasticsearch:
+    image: elasticsearch:7.16.1
+    environment:
+      discovery.type: single-node
+  logstash:
+    image: logstash:7.16.1
+    environment:
+      discovery.seed_hosts: logstash
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	templatesDir := filepath.Join(outDir, "chart", "templates")
+	configMaps := map[string][]string{
+		"configmap-elasticsearch-environment.yaml": {
+			`discovery.type: {{ index .Values.environment "elasticsearch" "discovery.type" | quote }}`,
+		},
+		"configmap-logstash-environment.yaml": {
+			`discovery.seed_hosts: {{ index .Values.environment "logstash" "discovery.seed_hosts" | quote }}`,
+		},
+	}
+	for name, expected := range configMaps {
+		configMap := readFile(t, filepath.Join(templatesDir, name))
+		for _, want := range expected {
+			if !strings.Contains(configMap, want) {
+				t.Fatalf("expected environment ConfigMap to contain %q\n%s", want, configMap)
+			}
+		}
+	}
+
+	zarfValues := readFile(t, filepath.Join(outDir, "values", "values.yaml"))
+	for _, want := range []string{
+		"###ZARF_VAR_ELASTICSEARCH_DISCOVERY_TYPE###",
+		"###ZARF_VAR_LOGSTASH_DISCOVERY_SEED_HOSTS###",
+	} {
+		if !strings.Contains(zarfValues, want) {
+			t.Fatalf("expected Zarf values to contain %q\n%s", want, zarfValues)
+		}
+	}
+}
+
 func TestWritePackageRejectsInvalidEnvironmentExternalization(t *testing.T) {
 	t.Parallel()
 
@@ -2872,15 +2925,15 @@ func TestWritePackageRejectsInvalidEnvironmentExternalization(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "non-portable environment name",
+			name: "invalid Kubernetes environment name",
 			app: model.App{
 				Package: model.Package{Name: "shop", Namespace: "shop", Version: "0.1.0"},
 				Services: []model.Service{{
 					Name: "api", Image: "ghcr.io/acme/api:1.0.0",
-					Env: []model.EnvVar{{Name: "DATABASE-URL", Value: "postgres://db"}},
+					Env: []model.EnvVar{{Name: "DATABASE/URL", Value: "postgres://db"}},
 				}},
 			},
-			wantErr: `invalid environment variable "DATABASE-URL" on service "api"`,
+			wantErr: `invalid environment variable "DATABASE/URL" on service "api"`,
 		},
 		{
 			name: "normalized environment variable collision",


### PR DESCRIPTION
## Description

Allows Compose environment names that match Kubernetes' established environment-variable and ConfigMap naming rules.

This fixes conversion of the Awesome Compose Elasticsearch, Logstash, and Kibana example, which uses `discovery.type` and `discovery.seed_hosts`.

## Changes

- Accept dots and hyphens in environment-variable names.
- Continue normalizing generated Zarf variable names and detecting collisions.
- Add regression coverage for the affected Elasticsearch and Logstash settings.
- Update the Compose support documentation.
- Regenerate the Awesome Compose compatibility matrix.

## Validation

- `gofmt -w internal/render/render.go internal/render/render_test.go`
- `git diff --check`
- `go test ./...`
- `./scripts/awesome_compose_matrix.py`
