### PR TITLE
feat: add conversion reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,21 @@ zarf package create out/ --flavor upstream
 zarf package deploy zarf-package-wordpress-*.tar.zst
 ```
 
-The transformation writes a Helm chart to `out/chart/`, a Zarf package definition to `out/zarf.yaml`, and deploy-time configuration to `out/values/`. Services with `build:` are built during `zarf package create` through a generated Buildx Bake definition. See [Compose support](docs/compose-support.md#local-dockerfile-builds) for Docker Compose version-specific conversion steps.
+The transformation writes these artifacts to `out/`:
 
-Mark a local-development dependency with long-syntax `depends_on` and
-`required: false` to keep it available to `docker compose up` while omitting it
-and its exclusive resources from the generated package.
+| Path | Purpose |
+| --- | --- |
+| `chart/` | Generated application Helm chart. |
+| `docs/` | Generated package documentation, including a human-readable `conversion.md` report. |
+| `values/` | Generated Helm values consumed during package deployment. |
+| `conversion.json` | Machine-readable conversion report for automation. |
+| `zarf.yaml` | Package metadata, components, images, variables, and documentation. |
 
 ## Documentation
 
 > [!TIP]
 > **Is Compose Bridge a good fit for your application?** Use the [Awesome Compose compatibility matrix](docs/awesome-compose-compatibility-matrix.md) as a practical benchmark. If your application depends on unsupported Compose features or needs deeper package customization, start with the [UDS reference package](https://github.com/uds-packages/reference-package) and build the package directly.
 
-- [Compose support](docs/compose-support.md) describes supported configuration, known limitations, and local Dockerfile builds.
+- [Compose support](docs/compose-support.md) describes supported configuration, known limitations, development-service exclusions, and local Dockerfile builds.
 - [UDS package generation](docs/uds-package.md) describes generated resources, `x-uds` extensions, secrets, and policy exemptions.
 - [`examples/full/compose.yaml`](examples/full/compose.yaml) demonstrates the complete supported configuration.

--- a/docs/compose-support.md
+++ b/docs/compose-support.md
@@ -23,9 +23,9 @@
 
 ## Excluding development services
 
-Use long-syntax `depends_on` with `required: false` for a dependency that is
-useful during local Compose development but should not be included in the
-generated package:
+Use long-syntax `depends_on` with `required: false` to keep a dependency
+available to `docker compose up` while omitting it and its exclusive resources
+from the generated package:
 
 ```yaml
 services:

--- a/docs/uds-package.md
+++ b/docs/uds-package.md
@@ -33,7 +33,7 @@ Use `x-uds` [Compose extension keys](https://docs.docker.com/reference/compose-f
 | `x-uds.metadata.version` | Package version override. A semantic upstream version receives `-uds.0`; an existing `<upstream>-uds.<sub-version>` value is preserved. |
 | `x-uds.metadata.labels` | Labels applied to generated UDS Package metadata. |
 | `x-uds.metadata.annotations` | Annotations applied to generated UDS Package metadata and Zarf package metadata. |
-| `x-uds.spec.network.expose[]` | Replace inferred expose rules. Missing fields are inferred from the service. |
+| `x-uds.spec.network.expose[]` | Replace inferred expose rules. Missing fields are inferred from the service; set an empty list to disable exposure. |
 | `x-uds.spec.network.allow[]` | Add network allow rules, deduplicated against inferred rules. |
 | `x-uds.spec.monitor[]` | Add Prometheus monitoring rules, with service metadata inferred when possible. |
 | `x-uds.spec.sso[]` | Replace inferred SSO clients. Set `x-uds.spec.sso: []` to disable inferred SSO. |

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -19,6 +19,8 @@ import (
 	"defenseunicorns/uds-compose-bridge/internal/model"
 )
 
+var invalidSettingPattern = regexp.MustCompile(`^invalid ([^:]+): (.+)$`)
+
 func LoadCanonicalFile(path string) (model.App, error) {
 	conversion, err := ConvertCanonicalFile(path)
 	return conversion.App, err
@@ -97,16 +99,107 @@ func convertCanonicalYAML(data []byte, sourcePath string) (model.Conversion, err
 
 	app, err := loadProject(*project, raw, excludedServices)
 	if err != nil {
-		report.Rejected = append(report.Rejected, model.ConversionDecision{
-			Path:    "compose",
-			Code:    "invalid-setting",
-			Message: err.Error(),
-		})
+		if decisions := loadProjectDecisions(err); len(decisions) > 0 {
+			removeConflictingTranslatedDecisions(&report, decisions)
+			report.Rejected = append(report.Rejected, decisions...)
+		} else {
+			report.Rejected = append(report.Rejected, model.ConversionDecision{
+				Path:    "compose",
+				Code:    "invalid-setting",
+				Message: err.Error(),
+			})
+		}
 		sortConversionReport(&report)
 		return model.Conversion{Report: report}, err
 	}
 	completeConversionReport(&report, *project, raw, app)
 	return model.Conversion{App: app, Report: report}, nil
+}
+
+func loadProjectDecisions(err error) []model.ConversionDecision {
+	message := err.Error()
+	if strings.HasPrefix(message, "unsupported fields:\n  - ") {
+		rawPaths := strings.Split(strings.TrimPrefix(message, "unsupported fields:\n  - "), "\n  - ")
+		decisions := make([]model.ConversionDecision, 0, len(rawPaths))
+		for _, rawPath := range rawPaths {
+			path, remediation := parseUnsupportedField(rawPath)
+			decisions = append(decisions, model.ConversionDecision{
+				Path:        path,
+				Code:        "unsupported-field",
+				Message:     "This x-uds field is not supported by the package translator.",
+				Remediation: remediation,
+			})
+		}
+		return decisions
+	}
+
+	matches := invalidSettingPattern.FindStringSubmatch(message)
+	if len(matches) != 3 {
+		return nil
+	}
+	path := matches[1]
+	return []model.ConversionDecision{{
+		Path:        path,
+		Code:        "invalid-setting",
+		Message:     matches[2],
+		Remediation: remediationForInvalidSetting(path),
+	}}
+}
+
+func parseUnsupportedField(rawPath string) (string, string) {
+	rawPath = strings.TrimSpace(rawPath)
+	parts := strings.SplitN(rawPath, " (", 2)
+	path := strings.TrimSpace(parts[0])
+	if len(parts) == 1 {
+		return path, "remove this field or replace it with a supported x-uds.metadata or x-uds.spec setting"
+	}
+	remediation := strings.TrimSuffix(parts[1], ")")
+	return path, remediation
+}
+
+func remediationForInvalidSetting(path string) string {
+	switch {
+	case path == "x-uds.metadata":
+		return "set x-uds.metadata to an object containing supported fields: name, version, labels, and annotations"
+	case path == "x-uds.metadata.name":
+		return "set x-uds.metadata.name to a lowercase DNS-1123-compatible value"
+	case path == "x-uds.metadata.version":
+		return "set x-uds.metadata.version to a non-empty version string such as 1.2.3 or 1.2.3-uds.0"
+	case strings.HasPrefix(path, "x-uds.metadata.labels"), strings.HasPrefix(path, "x-uds.metadata.annotations"):
+		return "set this metadata field to an object whose values are strings"
+	case path == "x-uds.spec":
+		return "set x-uds.spec to an object containing supported fields: network, monitor, sso, and caBundle"
+	case path == "x-uds.spec.network":
+		return "set x-uds.spec.network to an object containing expose and allow arrays"
+	case path == "x-uds.spec.network.expose", path == "x-uds.spec.network.allow", path == "x-uds.spec.monitor", path == "x-uds.spec.sso":
+		return "set this field to an array"
+	case path == "x-uds.spec.caBundle":
+		return "set x-uds.spec.caBundle to an object containing configMap"
+	case path == "x-uds.spec.caBundle.configMap":
+		return "set x-uds.spec.caBundle.configMap to an object containing name, key, labels, and annotations"
+	case strings.HasPrefix(path, "x-uds.spec.caBundle.configMap.labels"), strings.HasPrefix(path, "x-uds.spec.caBundle.configMap.annotations"):
+		return "set this configMap metadata field to an object whose values are strings"
+	case path == "x-uds.spec.caBundle.configMap.name", path == "x-uds.spec.caBundle.configMap.key":
+		return "set this field to a non-empty string"
+	default:
+		return "correct the invalid x-uds setting so it matches the expected Compose extension schema"
+	}
+}
+
+func removeConflictingTranslatedDecisions(report *model.ConversionReport, decisions []model.ConversionDecision) {
+	paths := make(map[string]struct{}, len(decisions))
+	for _, decision := range decisions {
+		paths[decision.Path] = struct{}{}
+	}
+
+	filtered := report.Translated[:0]
+	for _, decision := range report.Translated {
+		if _, conflict := paths[decision.Path]; conflict {
+			continue
+		}
+		filtered = append(filtered, decision)
+	}
+	report.Translated = filtered
 }
 
 // findExcludedServices identifies development-only dependencies. A service is

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -84,14 +84,17 @@ func convertCanonicalYAML(data []byte, sourcePath string) (model.Conversion, err
 	if err := validateCompatibility(*project, raw, excludedServices); err != nil {
 		var compatibilityErr *CompatibilityError
 		if errors.As(err, &compatibilityErr) {
+			decisions := make([]model.ConversionDecision, 0, len(compatibilityErr.Issues))
 			for _, issue := range compatibilityErr.Issues {
-				report.Rejected = append(report.Rejected, model.ConversionDecision{
+				decisions = append(decisions, model.ConversionDecision{
 					Path:        issue.Path,
 					Code:        issue.Code,
 					Message:     issue.Message,
 					Remediation: issue.Remediation,
 				})
 			}
+			removeConflictingTranslatedDecisions(&report, decisions)
+			report.Rejected = append(report.Rejected, decisions...)
 		}
 		sortConversionReport(&report)
 		return model.Conversion{Report: report}, err

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -2,6 +2,7 @@ package compose
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,21 +20,31 @@ import (
 )
 
 func LoadCanonicalFile(path string) (model.App, error) {
+	conversion, err := ConvertCanonicalFile(path)
+	return conversion.App, err
+}
+
+func ConvertCanonicalFile(path string) (model.Conversion, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return model.App{}, fmt.Errorf("read canonical compose file: %w", err)
+		return rejectedConversion("compose", "read-error", fmt.Errorf("read canonical compose file: %w", err))
 	}
-	return loadCanonicalYAML(data, path)
+	return convertCanonicalYAML(data, path)
 }
 
 func LoadCanonicalYAML(data []byte) (model.App, error) {
-	return loadCanonicalYAML(data, "")
+	conversion, err := ConvertCanonicalYAML(data)
+	return conversion.App, err
 }
 
-func loadCanonicalYAML(data []byte, sourcePath string) (model.App, error) {
+func ConvertCanonicalYAML(data []byte) (model.Conversion, error) {
+	return convertCanonicalYAML(data, "")
+}
+
+func convertCanonicalYAML(data []byte, sourcePath string) (model.Conversion, error) {
 	var raw map[string]any
 	if err := yamlv3.Unmarshal(data, &raw); err != nil {
-		return model.App{}, fmt.Errorf("decode canonical compose extensions: %w", err)
+		return rejectedConversion("compose", "decode-error", fmt.Errorf("decode canonical compose extensions: %w", err))
 	}
 	if raw == nil {
 		raw = map[string]any{}
@@ -64,14 +75,38 @@ func loadCanonicalYAML(data []byte, sourcePath string) (model.App, error) {
 		},
 	)
 	if err != nil {
-		return model.App{}, fmt.Errorf("decode canonical compose yaml: %w", err)
+		return rejectedConversion("compose", "decode-error", fmt.Errorf("decode canonical compose yaml: %w", err))
 	}
 	excludedServices := findExcludedServices(*project)
+	report := buildConversionReport(*project, raw, excludedServices)
 	if err := validateCompatibility(*project, raw, excludedServices); err != nil {
-		return model.App{}, err
+		var compatibilityErr *CompatibilityError
+		if errors.As(err, &compatibilityErr) {
+			for _, issue := range compatibilityErr.Issues {
+				report.Rejected = append(report.Rejected, model.ConversionDecision{
+					Path:        issue.Path,
+					Code:        issue.Code,
+					Message:     issue.Message,
+					Remediation: issue.Remediation,
+				})
+			}
+		}
+		sortConversionReport(&report)
+		return model.Conversion{Report: report}, err
 	}
 
-	return loadProject(*project, raw, excludedServices)
+	app, err := loadProject(*project, raw, excludedServices)
+	if err != nil {
+		report.Rejected = append(report.Rejected, model.ConversionDecision{
+			Path:    "compose",
+			Code:    "invalid-setting",
+			Message: err.Error(),
+		})
+		sortConversionReport(&report)
+		return model.Conversion{Report: report}, err
+	}
+	completeConversionReport(&report, *project, raw, app)
+	return model.Conversion{App: app, Report: report}, nil
 }
 
 // findExcludedServices identifies development-only dependencies. A service is

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -20,6 +20,7 @@ import (
 )
 
 var invalidSettingPattern = regexp.MustCompile(`^invalid ([^:]+): (.+)$`)
+var excludedServiceReferencePattern = regexp.MustCompile(`^(x-uds\.spec\.(?:network\.expose|monitor)) references excluded service "([^"]+)"$`)
 
 func LoadCanonicalFile(path string) (model.App, error) {
 	conversion, err := ConvertCanonicalFile(path)
@@ -137,16 +138,29 @@ func loadProjectDecisions(err error) []model.ConversionDecision {
 	}
 
 	matches := invalidSettingPattern.FindStringSubmatch(message)
-	if len(matches) != 3 {
-		return nil
+	if len(matches) == 3 {
+		path := matches[1]
+		return []model.ConversionDecision{{
+			Path:        path,
+			Code:        "invalid-setting",
+			Message:     matches[2],
+			Remediation: remediationForInvalidSetting(path),
+		}}
 	}
-	path := matches[1]
-	return []model.ConversionDecision{{
-		Path:        path,
-		Code:        "invalid-setting",
-		Message:     matches[2],
-		Remediation: remediationForInvalidSetting(path),
-	}}
+
+	matches = excludedServiceReferencePattern.FindStringSubmatch(message)
+	if len(matches) == 3 {
+		path := matches[1]
+		service := matches[2]
+		return []model.ConversionDecision{{
+			Path:        path,
+			Code:        "invalid-setting",
+			Message:     fmt.Sprintf("references excluded service %q", service),
+			Remediation: remediationForExcludedServiceReference(path, service),
+		}}
+	}
+
+	return nil
 }
 
 func parseUnsupportedField(rawPath string) (string, string) {
@@ -186,6 +200,17 @@ func remediationForInvalidSetting(path string) string {
 		return "set this field to a non-empty string"
 	default:
 		return "correct the invalid x-uds setting so it matches the expected Compose extension schema"
+	}
+}
+
+func remediationForExcludedServiceReference(path, service string) string {
+	switch path {
+	case "x-uds.spec.network.expose":
+		return fmt.Sprintf("remove %q from x-uds.spec.network.expose or mark the dependency as required so the service is packaged", service)
+	case "x-uds.spec.monitor":
+		return fmt.Sprintf("remove %q from x-uds.spec.monitor or mark the dependency as required so the service is packaged", service)
+	default:
+		return "update this x-uds setting to reference only packaged services"
 	}
 }
 

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -93,7 +93,7 @@ func convertCanonicalYAML(data []byte, sourcePath string) (model.Conversion, err
 					Remediation: issue.Remediation,
 				})
 			}
-			removeConflictingTranslatedDecisions(&report, decisions)
+			report.RemoveConflictingTranslated(decisions)
 			report.Rejected = append(report.Rejected, decisions...)
 		}
 		sortConversionReport(&report)
@@ -103,7 +103,7 @@ func convertCanonicalYAML(data []byte, sourcePath string) (model.Conversion, err
 	app, err := loadProject(*project, raw, excludedServices)
 	if err != nil {
 		if decisions := loadProjectDecisions(err); len(decisions) > 0 {
-			removeConflictingTranslatedDecisions(&report, decisions)
+			report.RemoveConflictingTranslated(decisions)
 			report.Rejected = append(report.Rejected, decisions...)
 		} else {
 			report.Rejected = append(report.Rejected, model.ConversionDecision{
@@ -187,22 +187,6 @@ func remediationForInvalidSetting(path string) string {
 	default:
 		return "correct the invalid x-uds setting so it matches the expected Compose extension schema"
 	}
-}
-
-func removeConflictingTranslatedDecisions(report *model.ConversionReport, decisions []model.ConversionDecision) {
-	paths := make(map[string]struct{}, len(decisions))
-	for _, decision := range decisions {
-		paths[decision.Path] = struct{}{}
-	}
-
-	filtered := report.Translated[:0]
-	for _, decision := range report.Translated {
-		if _, conflict := paths[decision.Path]; conflict {
-			continue
-		}
-		filtered = append(filtered, decision)
-	}
-	report.Translated = filtered
 }
 
 // findExcludedServices identifies development-only dependencies. A service is
@@ -797,6 +781,7 @@ func parseSpecConfig(config *model.Package, spec map[string]any, path string) er
 			return fmt.Errorf("invalid %s.network: must be an object", path)
 		}
 		if rawExpose, exists := network["expose"]; exists {
+			config.NetworkExposeConfigured = true
 			expose, ok := asSlice(rawExpose)
 			if !ok {
 				return fmt.Errorf("invalid %s.network.expose: must be an array", path)

--- a/internal/compose/compatibility.go
+++ b/internal/compose/compatibility.go
@@ -118,14 +118,14 @@ func validateCompatibility(project types.Project, raw map[string]any, excludedSe
 				continue
 			}
 			dependency, exists := project.Services[dependencyName]
-			if !exists || len(dependency.Ports) > 0 || len(dependency.Expose) > 0 {
+			if !exists || hasDeclaredTCPPort(dependency) {
 				continue
 			}
 			issues = append(issues, CompatibilityIssue{
 				Code:        "dependency-port",
 				Path:        path + ".depends_on." + dependencyName,
-				Message:     fmt.Sprintf("dependency %q has no declared service port for generated wait logic", dependencyName),
-				Remediation: fmt.Sprintf("declare ports or expose on service %q, or mark the dependency required: false", dependencyName),
+				Message:     fmt.Sprintf("dependency %q has no declared TCP service port for generated wait logic", dependencyName),
+				Remediation: fmt.Sprintf("declare a TCP port in ports or expose on service %q, or mark the dependency required: false", dependencyName),
 			})
 		}
 
@@ -173,4 +173,25 @@ func validateCompatibility(project types.Project, raw map[string]any, excludedSe
 		return issues[i].Path < issues[j].Path
 	})
 	return &CompatibilityError{Issues: issues}
+}
+
+func hasDeclaredTCPPort(service types.ServiceConfig) bool {
+	for _, port := range service.Ports {
+		if port.Target == 0 {
+			continue
+		}
+		if protocolOrDefault(port.Protocol) == "TCP" {
+			return true
+		}
+	}
+	for _, token := range service.Expose {
+		port, proto, err := parsePortToken(token)
+		if err != nil || port <= 0 {
+			continue
+		}
+		if protocolOrDefault(proto) == "TCP" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/compose/compatibility.go
+++ b/internal/compose/compatibility.go
@@ -113,6 +113,22 @@ func validateCompatibility(project types.Project, raw map[string]any, excludedSe
 			}
 		}
 
+		for dependencyName := range service.DependsOn {
+			if _, excluded := excludedServices[dependencyName]; excluded {
+				continue
+			}
+			dependency, exists := project.Services[dependencyName]
+			if !exists || len(dependency.Ports) > 0 || len(dependency.Expose) > 0 {
+				continue
+			}
+			issues = append(issues, CompatibilityIssue{
+				Code:        "dependency-port",
+				Path:        path + ".depends_on." + dependencyName,
+				Message:     fmt.Sprintf("dependency %q has no declared service port for generated wait logic", dependencyName),
+				Remediation: fmt.Sprintf("declare ports or expose on service %q, or mark the dependency required: false", dependencyName),
+			})
+		}
+
 		for key := range rawService {
 			if strings.HasPrefix(key, "x-") {
 				continue

--- a/internal/compose/report.go
+++ b/internal/compose/report.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/types"
 
+	"defenseunicorns/uds-compose-bridge/internal/inference"
 	"defenseunicorns/uds-compose-bridge/internal/model"
 )
 
@@ -111,6 +112,15 @@ func buildConversionReport(project types.Project, raw map[string]any, excludedSe
 		for _, key := range keys {
 			path := servicePath + "." + key
 			switch key {
+			case "depends_on":
+				if hasPackagedDependency(service.DependsOn, excludedServices) {
+					report.Translated = append(report.Translated, translatedDecision(path, translatedServiceSettings[key]))
+				} else {
+					report.Ignored = append(report.Ignored, model.ConversionDecision{
+						Path:    path,
+						Message: "Every dependency references an excluded development-only service, so no init container is generated.",
+					})
+				}
 			case "container_name":
 				report.Ignored = append(report.Ignored, model.ConversionDecision{
 					Path:    path,
@@ -178,6 +188,15 @@ func buildConversionReport(project types.Project, raw map[string]any, excludedSe
 	}
 
 	return report
+}
+
+func hasPackagedDependency(dependencies types.DependsOnConfig, excludedServices map[string]struct{}) bool {
+	for name := range dependencies {
+		if _, excluded := excludedServices[name]; !excluded {
+			return true
+		}
+	}
+	return false
 }
 
 func translatedDecision(path, target string) model.ConversionDecision {
@@ -383,15 +402,11 @@ func completeConversionReport(report *model.ConversionReport, project types.Proj
 		}
 	}
 
-	if len(app.Package.NetworkExpose) == 0 {
-		primaryExposedService := ""
+	if !app.Package.NetworkExposeConfigured {
 		for _, service := range app.Services {
 			for _, port := range service.Ports {
 				if !port.Published {
 					continue
-				}
-				if primaryExposedService == "" {
-					primaryExposedService = service.Name
 				}
 				report.Inferred = append(report.Inferred, model.ConversionDecision{
 					Path:    "x-uds.spec.network.expose",
@@ -401,11 +416,33 @@ func completeConversionReport(report *model.ConversionReport, project types.Proj
 				break
 			}
 		}
-		if !app.Package.SSOConfigured && primaryExposedService != "" {
+	}
+	report.Inferred = append(report.Inferred, model.ConversionDecision{
+		Path:    "x-uds.spec.network.allow",
+		Value:   "ingress and egress",
+		Message: "Inferred package-local network allow rules for generated workloads.",
+	})
+
+	if !app.Package.SSOConfigured {
+		_, primaryExposedService := inference.PrimaryExposedService(app)
+		if primaryExposedService != "" {
 			report.Inferred = append(report.Inferred, model.ConversionDecision{
 				Path:    "x-uds.spec.sso",
 				Value:   primaryExposedService,
-				Message: "Inferred default SSO client configuration from the inferred service exposure.",
+				Message: "Inferred default SSO client configuration from the service exposure.",
+			})
+		}
+	}
+
+	if !app.Package.MonitorConfigured {
+		for _, service := range app.Services {
+			if len(inference.MetricsPorts(service)) == 0 {
+				continue
+			}
+			report.Inferred = append(report.Inferred, model.ConversionDecision{
+				Path:    "x-uds.spec.monitor",
+				Value:   service.Name,
+				Message: "Inferred ServiceMonitor configuration from the service's metrics ports.",
 			})
 		}
 	}

--- a/internal/compose/report.go
+++ b/internal/compose/report.go
@@ -1,0 +1,381 @@
+package compose
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/compose-spec/compose-go/v2/types"
+
+	"defenseunicorns/uds-compose-bridge/internal/model"
+)
+
+var translatedServiceSettings = map[string]string{
+	"build":        "generated Buildx Bake service",
+	"cap_add":      "Deployment container security context",
+	"cap_drop":     "Deployment container security context",
+	"command":      "Deployment container arguments",
+	"configs":      "Deployment config volume mounts",
+	"depends_on":   "Deployment dependency init containers",
+	"entrypoint":   "Deployment container command",
+	"environment":  "environment ConfigMap and deploy-time variables",
+	"env_file":     "environment ConfigMap and deploy-time variables",
+	"expose":       "Kubernetes Service ports",
+	"hostname":     "Deployment Pod hostname",
+	"image":        "Zarf package image and Deployment container image",
+	"networks":     "UDS network policy selectors",
+	"ports":        "Kubernetes Service ports and UDS gateway exposure",
+	"privileged":   "Deployment container security context and UDS exemption",
+	"secrets":      "Deployment secret volume mounts",
+	"security_opt": "Deployment container security context and UDS exemption",
+	"stdin_open":   "Deployment container stdin setting",
+	"user":         "Deployment container security context",
+}
+
+func rejectedConversion(path, code string, err error) (model.Conversion, error) {
+	report := newConversionReport()
+	report.Rejected = append(report.Rejected, model.ConversionDecision{
+		Path:    path,
+		Code:    code,
+		Message: err.Error(),
+	})
+	return model.Conversion{Report: report}, err
+}
+
+func newConversionReport() model.ConversionReport {
+	return model.ConversionReport{
+		Translated: []model.ConversionDecision{},
+		Inferred:   []model.ConversionDecision{},
+		Ignored:    []model.ConversionDecision{},
+		Rejected:   []model.ConversionDecision{},
+	}
+}
+
+func buildConversionReport(project types.Project, raw map[string]any, excludedServices map[string]struct{}) model.ConversionReport {
+	report := newConversionReport()
+	if _, exists := raw["name"]; exists {
+		report.Translated = append(report.Translated, model.ConversionDecision{
+			Path:    "name",
+			Target:  "package metadata name",
+			Message: "Used the Compose project name as the generated package identity.",
+		})
+	}
+
+	rawServices, _ := asMap(raw["services"])
+	serviceNames := make([]string, 0, len(project.Services))
+	for name := range project.Services {
+		serviceNames = append(serviceNames, name)
+	}
+	sort.Strings(serviceNames)
+	for _, serviceName := range serviceNames {
+		service := project.Services[serviceName]
+		servicePath := "services." + serviceName
+		if _, excluded := excludedServices[serviceName]; excluded {
+			report.Ignored = append(report.Ignored, model.ConversionDecision{
+				Path:    servicePath,
+				Message: "Excluded this development-only service because every depends_on reference marks it required: false.",
+			})
+			continue
+		}
+
+		rawService, _ := asMap(rawServices[serviceName])
+		keys := sortedNames(rawService)
+		for _, key := range keys {
+			path := servicePath + "." + key
+			switch key {
+			case "container_name":
+				report.Ignored = append(report.Ignored, model.ConversionDecision{
+					Path:    path,
+					Message: "Kubernetes resources use the Compose service name, so container_name has no effect.",
+				})
+			case "restart":
+				report.Ignored = append(report.Ignored, model.ConversionDecision{
+					Path:    path,
+					Message: "Kubernetes controls workload restarts, so the Compose restart policy is not translated.",
+				})
+			case "profiles":
+				report.Ignored = append(report.Ignored, model.ConversionDecision{
+					Path:    path,
+					Message: "Compose profile selection is resolved before package generation and is not represented in the package.",
+				})
+			case "volumes":
+				addVolumeDecisions(&report, servicePath, service.Volumes)
+			case "deploy":
+				addDeployDecisions(&report, path, rawService[key])
+			case "healthcheck":
+				if service.HealthCheck == nil || service.HealthCheck.Disable || len(service.HealthCheck.Test) == 0 {
+					report.Ignored = append(report.Ignored, model.ConversionDecision{
+						Path:    path,
+						Message: "The healthcheck is disabled or has no command, so no Kubernetes probe is generated.",
+					})
+				} else {
+					report.Translated = append(report.Translated, translatedDecision(path, "Deployment liveness probe"))
+				}
+			default:
+				if target, ok := translatedServiceSettings[key]; ok {
+					report.Translated = append(report.Translated, translatedDecision(path, target))
+				} else if strings.HasPrefix(key, "x-") {
+					report.Ignored = append(report.Ignored, model.ConversionDecision{
+						Path:    path,
+						Message: "This service extension is not consumed by the UDS package translator.",
+					})
+				}
+			}
+		}
+	}
+
+	addNetworkDecisions(&report, project, raw, excludedServices)
+	addUDSExtensionDecisions(&report, raw)
+	for _, key := range sortedNames(raw) {
+		if key == "version" {
+			report.Ignored = append(report.Ignored, model.ConversionDecision{
+				Path:    key,
+				Message: "The legacy Compose schema version does not affect the generated package.",
+			})
+		} else if strings.HasPrefix(key, "x-") && key != "x-uds" {
+			report.Ignored = append(report.Ignored, model.ConversionDecision{
+				Path:    key,
+				Message: "This top-level Compose extension is not consumed by the UDS package translator.",
+			})
+		}
+	}
+
+	return report
+}
+
+func translatedDecision(path, target string) model.ConversionDecision {
+	return model.ConversionDecision{
+		Path:    path,
+		Target:  target,
+		Message: "Translated this Compose setting into generated package configuration.",
+	}
+}
+
+func addVolumeDecisions(report *model.ConversionReport, servicePath string, volumes []types.ServiceVolumeConfig) {
+	for i, volume := range volumes {
+		path := fmt.Sprintf("%s.volumes[%d]", servicePath, i)
+		mountType := strings.ToLower(strings.TrimSpace(volume.Type))
+		if mountType == "" && looksLikePath(volume.Source) {
+			mountType = types.VolumeTypeBind
+		}
+		if mountType == types.VolumeTypeBind {
+			report.Ignored = append(report.Ignored, model.ConversionDecision{
+				Path:    path,
+				Message: "Bind mounts have no portable Kubernetes equivalent; use a named volume, config, or secret.",
+			})
+			continue
+		}
+		report.Translated = append(report.Translated, translatedDecision(path, "Deployment volume mount"))
+	}
+}
+
+func addDeployDecisions(report *model.ConversionReport, path string, value any) {
+	deploy, ok := asMap(value)
+	if !ok {
+		return
+	}
+	for _, key := range sortedNames(deploy) {
+		settingPath := path + "." + key
+		if key == "resources" {
+			report.Translated = append(report.Translated, translatedDecision(settingPath, "Deployment resource requests and limits"))
+			continue
+		}
+		report.Ignored = append(report.Ignored, model.ConversionDecision{
+			Path:    settingPath,
+			Message: "Only deploy.resources is translated; Kubernetes and UDS control this deploy setting.",
+		})
+	}
+}
+
+func addNetworkDecisions(report *model.ConversionReport, project types.Project, raw map[string]any, excludedServices map[string]struct{}) {
+	used := map[string]struct{}{}
+	for serviceName, service := range project.Services {
+		if _, excluded := excludedServices[serviceName]; excluded {
+			continue
+		}
+		for networkName := range service.Networks {
+			used[networkName] = struct{}{}
+		}
+	}
+	rawNetworks, _ := asMap(raw["networks"])
+	for _, name := range sortedNames(project.Networks) {
+		path := "networks." + name
+		if _, exists := used[name]; !exists {
+			report.Ignored = append(report.Ignored, model.ConversionDecision{
+				Path:    path,
+				Message: "The network is not used by a packaged service.",
+			})
+			continue
+		}
+		if _, configured := rawNetworks[name]; configured {
+			report.Translated = append(report.Translated, translatedDecision(path, "UDS network policy selectors"))
+		} else {
+			report.Inferred = append(report.Inferred, model.ConversionDecision{
+				Path:    path,
+				Value:   name,
+				Message: "Inferred the Compose default network used for generated UDS network policy selectors.",
+			})
+		}
+		if bool(project.Networks[name].External) {
+			report.Ignored = append(report.Ignored, model.ConversionDecision{
+				Path:    path + ".external",
+				Message: "External Compose network semantics cannot identify Kubernetes peers; the network is treated as package-local.",
+			})
+		}
+	}
+}
+
+func addUDSExtensionDecisions(report *model.ConversionReport, raw map[string]any) {
+	uds, ok := asMap(raw["x-uds"])
+	if !ok {
+		return
+	}
+	if metadata, ok := asMap(uds["metadata"]); ok {
+		for _, key := range sortedNames(metadata) {
+			report.Translated = append(report.Translated, translatedDecision("x-uds.metadata."+key, "package metadata"))
+		}
+	}
+	if spec, ok := asMap(uds["spec"]); ok {
+		for _, key := range sortedNames(spec) {
+			path := "x-uds.spec." + key
+			if key == "network" {
+				if network, ok := asMap(spec[key]); ok {
+					for _, networkKey := range sortedNames(network) {
+						report.Translated = append(report.Translated, translatedDecision(path+"."+networkKey, "UDS Package custom resource"))
+					}
+					continue
+				}
+			}
+			report.Translated = append(report.Translated, translatedDecision(path, "UDS Package custom resource"))
+		}
+	}
+}
+
+func completeConversionReport(report *model.ConversionReport, project types.Project, raw map[string]any, app model.App) {
+	addResourceDecisions(report, project, app)
+	uds, _ := asMap(raw["x-uds"])
+	metadata, _ := asMap(uds["metadata"])
+	if strings.TrimSpace(asString(metadata["name"])) == "" {
+		report.Inferred = append(report.Inferred, model.ConversionDecision{
+			Path:    "x-uds.metadata.name",
+			Value:   app.Package.Name,
+			Message: "Inferred the package name and Kubernetes namespace from the Compose project name.",
+		})
+	}
+	if !app.Package.VersionConfigured {
+		report.Inferred = append(report.Inferred, model.ConversionDecision{
+			Path:    "x-uds.metadata.version",
+			Value:   app.Package.Version,
+			Message: "Inferred the package version from the primary service image tag, falling back to the bridge default when necessary.",
+		})
+	}
+
+	rawServices, _ := asMap(raw["services"])
+	for _, service := range app.Services {
+		rawService := findRawService(rawServices, service.Name)
+		if service.Build != nil {
+			if strings.TrimSpace(asString(rawService["image"])) == "" {
+				report.Inferred = append(report.Inferred, model.ConversionDecision{
+					Path:    "services." + service.Name + ".image",
+					Value:   service.Image,
+					Message: "Generated an internal image reference for the local build.",
+				})
+			}
+		}
+	}
+
+	if len(app.Package.NetworkExpose) == 0 {
+		for _, service := range app.Services {
+			for _, port := range service.Ports {
+				if !port.Published {
+					continue
+				}
+				report.Inferred = append(report.Inferred, model.ConversionDecision{
+					Path:    "x-uds.spec.network.expose",
+					Value:   service.Name,
+					Message: "Inferred a tenant gateway exposure from the service's published ports.",
+				})
+				break
+			}
+		}
+	}
+
+	sortConversionReport(report)
+}
+
+func findRawService(rawServices map[string]any, normalizedName string) map[string]any {
+	for name, value := range rawServices {
+		normalized, err := normalizeName(name)
+		if err != nil || normalized != normalizedName {
+			continue
+		}
+		service, _ := asMap(value)
+		return service
+	}
+	return nil
+}
+
+func addResourceDecisions(report *model.ConversionReport, project types.Project, app model.App) {
+	addNamedResourceDecisions(report, "volumes", sortedNames(project.Volumes), func(name string) bool {
+		normalized, err := normalizeName(name)
+		if err != nil {
+			return false
+		}
+		_, exists := app.Volumes[normalized]
+		return exists
+	}, "PersistentVolumeClaim")
+	addNamedResourceDecisions(report, "secrets", sortedNames(project.Secrets), func(name string) bool {
+		normalized, err := normalizeName(name)
+		if err != nil {
+			return false
+		}
+		_, exists := app.Secrets[normalized]
+		return exists
+	}, "Kubernetes Secret configuration")
+	addNamedResourceDecisions(report, "configs", sortedNames(project.Configs), func(name string) bool {
+		normalized, err := normalizeName(name)
+		if err != nil {
+			return false
+		}
+		_, exists := app.Configs[normalized]
+		return exists
+	}, "Kubernetes ConfigMap configuration")
+}
+
+func addNamedResourceDecisions(report *model.ConversionReport, kind string, names []string, retained func(string) bool, target string) {
+	for _, name := range names {
+		path := kind + "." + name
+		if retained(name) {
+			report.Translated = append(report.Translated, translatedDecision(path, target))
+		} else {
+			report.Ignored = append(report.Ignored, model.ConversionDecision{
+				Path:    path,
+				Message: "The resource is not referenced by a packaged service.",
+			})
+		}
+	}
+}
+
+func sortConversionReport(report *model.ConversionReport) {
+	less := func(items []model.ConversionDecision) {
+		sort.SliceStable(items, func(i, j int) bool {
+			if items[i].Path == items[j].Path {
+				return items[i].Code < items[j].Code
+			}
+			return items[i].Path < items[j].Path
+		})
+	}
+	less(report.Translated)
+	less(report.Inferred)
+	less(report.Ignored)
+	less(report.Rejected)
+}
+
+func sortedNames[M ~map[string]V, V any](values M) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/compose/report.go
+++ b/internal/compose/report.go
@@ -12,25 +12,22 @@ import (
 )
 
 var translatedServiceSettings = map[string]string{
-	"build":        "generated Buildx Bake service",
-	"cap_add":      "Deployment container security context",
-	"cap_drop":     "Deployment container security context",
-	"command":      "Deployment container arguments",
-	"configs":      "Deployment config volume mounts",
-	"depends_on":   "Deployment dependency init containers",
-	"entrypoint":   "Deployment container command",
-	"environment":  "environment ConfigMap and deploy-time variables",
-	"env_file":     "environment ConfigMap and deploy-time variables",
-	"expose":       "Kubernetes Service ports",
-	"hostname":     "Deployment Pod hostname",
-	"image":        "Zarf package image and Deployment container image",
-	"networks":     "UDS network policy selectors",
-	"ports":        "Kubernetes Service ports and UDS gateway exposure",
-	"privileged":   "Deployment container security context and UDS exemption",
-	"secrets":      "Deployment secret volume mounts",
-	"security_opt": "Deployment container security context and UDS exemption",
-	"stdin_open":   "Deployment container stdin setting",
-	"user":         "Deployment container security context",
+	"cap_add":     "Deployment container security context",
+	"cap_drop":    "Deployment container security context",
+	"command":     "Deployment container arguments",
+	"configs":     "Deployment config volume mounts",
+	"depends_on":  "Deployment dependency init containers",
+	"entrypoint":  "Deployment container command",
+	"environment": "environment ConfigMap and deploy-time variables",
+	"expose":      "Kubernetes Service ports",
+	"hostname":    "Deployment Pod hostname",
+	"image":       "Zarf package image and Deployment container image",
+	"networks":    "UDS network policy selectors",
+	"ports":       "Kubernetes Service ports",
+	"privileged":  "Deployment container security context and UDS exemption",
+	"secrets":     "Deployment secret volume mounts",
+	"stdin_open":  "Deployment container stdin setting",
+	"user":        "Deployment container security context",
 }
 
 var supportedUDSMetadataKeys = map[string]struct{}{
@@ -55,11 +52,23 @@ var supportedUDSNetworkKeys = map[string]struct{}{
 func rejectedConversion(path, code string, err error) (model.Conversion, error) {
 	report := newConversionReport()
 	report.Rejected = append(report.Rejected, model.ConversionDecision{
-		Path:    path,
-		Code:    code,
-		Message: err.Error(),
+		Path:        path,
+		Code:        code,
+		Message:     err.Error(),
+		Remediation: rejectedConversionRemediation(code),
 	})
 	return model.Conversion{Report: report}, err
+}
+
+func rejectedConversionRemediation(code string) string {
+	switch code {
+	case "read-error":
+		return "verify the Compose input file path exists and is readable by the converter"
+	case "decode-error":
+		return "fix malformed Compose YAML and ensure extension values match the expected schema"
+	default:
+		return "address the reported conversion error and rerun conversion"
+	}
 }
 
 func newConversionReport() model.ConversionReport {
@@ -112,6 +121,8 @@ func buildConversionReport(project types.Project, raw map[string]any, excludedSe
 		for _, key := range keys {
 			path := servicePath + "." + key
 			switch key {
+			case "build":
+				addBuildDecisions(&report, path, rawService[key])
 			case "depends_on":
 				if hasPackagedDependency(service.DependsOn, excludedServices) {
 					report.Translated = append(report.Translated, translatedDecision(path, translatedServiceSettings[key]))
@@ -158,6 +169,13 @@ func buildConversionReport(project types.Project, raw map[string]any, excludedSe
 				} else {
 					report.Translated = append(report.Translated, translatedDecision(path, translatedServiceSettings[key]))
 				}
+			case "env_file":
+				report.Ignored = append(report.Ignored, model.ConversionDecision{
+					Path:    path,
+					Message: "env_file entries are not resolved by this converter; resolve them into explicit environment values in canonical Compose input.",
+				})
+			case "security_opt":
+				addSecurityOptionDecisions(&report, path, service.SecurityOpt)
 			default:
 				if target, ok := translatedServiceSettings[key]; ok {
 					report.Translated = append(report.Translated, translatedDecision(path, target))
@@ -224,6 +242,46 @@ func addVolumeDecisions(report *model.ConversionReport, servicePath string, volu
 		if mountType == "" || mountType == types.VolumeTypeVolume {
 			report.Translated = append(report.Translated, translatedDecision(path, "Deployment volume mount"))
 		}
+	}
+}
+
+func addBuildDecisions(report *model.ConversionReport, path string, value any) {
+	build, ok := asMap(value)
+	if !ok {
+		report.Translated = append(report.Translated, translatedDecision(path, "generated Buildx Bake service"))
+		return
+	}
+	for _, key := range sortedNames(build) {
+		settingPath := path + "." + key
+		if key == "tags" {
+			report.Ignored = append(report.Ignored, model.ConversionDecision{
+				Path:    settingPath,
+				Message: "build.tags is not translated; generated image tags are controlled by the converter.",
+			})
+			continue
+		}
+		report.Translated = append(report.Translated, translatedDecision(settingPath, "generated Buildx Bake service"))
+	}
+}
+
+func addSecurityOptionDecisions(report *model.ConversionReport, path string, options []string) {
+	if len(options) == 0 {
+		report.Ignored = append(report.Ignored, model.ConversionDecision{
+			Path:    path,
+			Message: "security_opt is not translated unless it is seccomp:unconfined.",
+		})
+		return
+	}
+	for i, option := range options {
+		optionPath := fmt.Sprintf("%s[%d]", path, i)
+		if strings.EqualFold(strings.TrimSpace(option), "seccomp:unconfined") {
+			report.Translated = append(report.Translated, translatedDecision(optionPath, "UDS exemption"))
+			continue
+		}
+		report.Ignored = append(report.Ignored, model.ConversionDecision{
+			Path:    optionPath,
+			Message: "This security_opt value is not translated; only seccomp:unconfined generates a UDS exemption.",
+		})
 	}
 }
 

--- a/internal/compose/report.go
+++ b/internal/compose/report.go
@@ -202,7 +202,9 @@ func addVolumeDecisions(report *model.ConversionReport, servicePath string, volu
 			})
 			continue
 		}
-		report.Translated = append(report.Translated, translatedDecision(path, "Deployment volume mount"))
+		if mountType == "" || mountType == types.VolumeTypeVolume {
+			report.Translated = append(report.Translated, translatedDecision(path, "Deployment volume mount"))
+		}
 	}
 }
 
@@ -302,6 +304,13 @@ func addUDSExtensionDecisions(report *model.ConversionReport, raw map[string]any
 	if metadata, ok := asMap(uds["metadata"]); ok {
 		for _, key := range sortedNames(metadata) {
 			path := "x-uds.metadata." + key
+			if key == "name" && strings.TrimSpace(asString(metadata[key])) == "" {
+				report.Ignored = append(report.Ignored, model.ConversionDecision{
+					Path:    path,
+					Message: "This metadata.name value is empty or invalid, so package identity is inferred from the Compose project name.",
+				})
+				continue
+			}
 			if _, supported := supportedUDSMetadataKeys[key]; supported {
 				report.Translated = append(report.Translated, translatedDecision(path, "package metadata"))
 				continue
@@ -375,10 +384,14 @@ func completeConversionReport(report *model.ConversionReport, project types.Proj
 	}
 
 	if len(app.Package.NetworkExpose) == 0 {
+		primaryExposedService := ""
 		for _, service := range app.Services {
 			for _, port := range service.Ports {
 				if !port.Published {
 					continue
+				}
+				if primaryExposedService == "" {
+					primaryExposedService = service.Name
 				}
 				report.Inferred = append(report.Inferred, model.ConversionDecision{
 					Path:    "x-uds.spec.network.expose",
@@ -387,6 +400,13 @@ func completeConversionReport(report *model.ConversionReport, project types.Proj
 				})
 				break
 			}
+		}
+		if !app.Package.SSOConfigured && primaryExposedService != "" {
+			report.Inferred = append(report.Inferred, model.ConversionDecision{
+				Path:    "x-uds.spec.sso",
+				Value:   primaryExposedService,
+				Message: "Inferred default SSO client configuration from the inferred service exposure.",
+			})
 		}
 	}
 

--- a/internal/compose/report.go
+++ b/internal/compose/report.go
@@ -32,6 +32,25 @@ var translatedServiceSettings = map[string]string{
 	"user":         "Deployment container security context",
 }
 
+var supportedUDSMetadataKeys = map[string]struct{}{
+	"name":        {},
+	"version":     {},
+	"labels":      {},
+	"annotations": {},
+}
+
+var supportedUDSSpecKeys = map[string]struct{}{
+	"network":  {},
+	"monitor":  {},
+	"sso":      {},
+	"caBundle": {},
+}
+
+var supportedUDSNetworkKeys = map[string]struct{}{
+	"expose": {},
+	"allow":  {},
+}
+
 func rejectedConversion(path, code string, err error) (model.Conversion, error) {
 	report := newConversionReport()
 	report.Rejected = append(report.Rejected, model.ConversionDecision{
@@ -53,12 +72,21 @@ func newConversionReport() model.ConversionReport {
 
 func buildConversionReport(project types.Project, raw map[string]any, excludedServices map[string]struct{}) model.ConversionReport {
 	report := newConversionReport()
+	uds, _ := asMap(raw["x-uds"])
+	metadata, _ := asMap(uds["metadata"])
 	if _, exists := raw["name"]; exists {
-		report.Translated = append(report.Translated, model.ConversionDecision{
-			Path:    "name",
-			Target:  "package metadata name",
-			Message: "Used the Compose project name as the generated package identity.",
-		})
+		if strings.TrimSpace(asString(metadata["name"])) != "" {
+			report.Ignored = append(report.Ignored, model.ConversionDecision{
+				Path:    "name",
+				Message: "x-uds.metadata.name overrides the Compose project name for the generated package identity.",
+			})
+		} else {
+			report.Translated = append(report.Translated, model.ConversionDecision{
+				Path:    "name",
+				Target:  "package metadata name",
+				Message: "Used the Compose project name as the generated package identity.",
+			})
+		}
 	}
 
 	rawServices, _ := asMap(raw["services"])
@@ -110,6 +138,15 @@ func buildConversionReport(project types.Project, raw map[string]any, excludedSe
 					})
 				} else {
 					report.Translated = append(report.Translated, translatedDecision(path, "Deployment liveness probe"))
+				}
+			case "image":
+				if service.Build != nil {
+					report.Ignored = append(report.Ignored, model.ConversionDecision{
+						Path:    path,
+						Message: "Local build services use a generated internal image reference instead of the Compose image setting.",
+					})
+				} else {
+					report.Translated = append(report.Translated, translatedDecision(path, translatedServiceSettings[key]))
 				}
 			default:
 				if target, ok := translatedServiceSettings[key]; ok {
@@ -177,13 +214,45 @@ func addDeployDecisions(report *model.ConversionReport, path string, value any) 
 	for _, key := range sortedNames(deploy) {
 		settingPath := path + "." + key
 		if key == "resources" {
-			report.Translated = append(report.Translated, translatedDecision(settingPath, "Deployment resource requests and limits"))
+			addDeployResourceDecisions(report, settingPath, deploy[key])
 			continue
 		}
 		report.Ignored = append(report.Ignored, model.ConversionDecision{
 			Path:    settingPath,
 			Message: "Only deploy.resources is translated; Kubernetes and UDS control this deploy setting.",
 		})
+	}
+}
+
+func addDeployResourceDecisions(report *model.ConversionReport, path string, value any) {
+	resources, ok := asMap(value)
+	if !ok {
+		return
+	}
+	for _, key := range sortedNames(resources) {
+		settingPath := path + "." + key
+		if key != "limits" && key != "reservations" {
+			report.Ignored = append(report.Ignored, model.ConversionDecision{
+				Path:    settingPath,
+				Message: "Only deploy.resources.limits and deploy.resources.reservations CPU and memory settings are translated.",
+			})
+			continue
+		}
+		resourceSet, ok := asMap(resources[key])
+		if !ok {
+			continue
+		}
+		for _, resourceKey := range sortedNames(resourceSet) {
+			resourcePath := settingPath + "." + resourceKey
+			if resourceKey == "cpus" || resourceKey == "memory" {
+				report.Translated = append(report.Translated, translatedDecision(resourcePath, "Deployment resource requests and limits"))
+				continue
+			}
+			report.Ignored = append(report.Ignored, model.ConversionDecision{
+				Path:    resourcePath,
+				Message: "Only CPU and memory resource requests and limits are translated from deploy.resources.",
+			})
+		}
 	}
 }
 
@@ -232,7 +301,15 @@ func addUDSExtensionDecisions(report *model.ConversionReport, raw map[string]any
 	}
 	if metadata, ok := asMap(uds["metadata"]); ok {
 		for _, key := range sortedNames(metadata) {
-			report.Translated = append(report.Translated, translatedDecision("x-uds.metadata."+key, "package metadata"))
+			path := "x-uds.metadata." + key
+			if _, supported := supportedUDSMetadataKeys[key]; supported {
+				report.Translated = append(report.Translated, translatedDecision(path, "package metadata"))
+				continue
+			}
+			report.Ignored = append(report.Ignored, model.ConversionDecision{
+				Path:    path,
+				Message: "This x-uds metadata field is not consumed by the package translator.",
+			})
 		}
 	}
 	if spec, ok := asMap(uds["spec"]); ok {
@@ -241,12 +318,27 @@ func addUDSExtensionDecisions(report *model.ConversionReport, raw map[string]any
 			if key == "network" {
 				if network, ok := asMap(spec[key]); ok {
 					for _, networkKey := range sortedNames(network) {
-						report.Translated = append(report.Translated, translatedDecision(path+"."+networkKey, "UDS Package custom resource"))
+						networkPath := path + "." + networkKey
+						if _, supported := supportedUDSNetworkKeys[networkKey]; supported {
+							report.Translated = append(report.Translated, translatedDecision(networkPath, "UDS Package custom resource"))
+							continue
+						}
+						report.Ignored = append(report.Ignored, model.ConversionDecision{
+							Path:    networkPath,
+							Message: "Only x-uds.spec.network.expose and x-uds.spec.network.allow are consumed by the package translator.",
+						})
 					}
 					continue
 				}
 			}
-			report.Translated = append(report.Translated, translatedDecision(path, "UDS Package custom resource"))
+			if _, supported := supportedUDSSpecKeys[key]; supported {
+				report.Translated = append(report.Translated, translatedDecision(path, "UDS Package custom resource"))
+				continue
+			}
+			report.Ignored = append(report.Ignored, model.ConversionDecision{
+				Path:    path,
+				Message: "This x-uds spec field is not consumed by the package translator.",
+			})
 		}
 	}
 }
@@ -272,15 +364,13 @@ func completeConversionReport(report *model.ConversionReport, project types.Proj
 
 	rawServices, _ := asMap(raw["services"])
 	for _, service := range app.Services {
-		rawService := findRawService(rawServices, service.Name)
+		rawServiceName, _ := findRawService(rawServices, service.Name)
 		if service.Build != nil {
-			if strings.TrimSpace(asString(rawService["image"])) == "" {
-				report.Inferred = append(report.Inferred, model.ConversionDecision{
-					Path:    "services." + service.Name + ".image",
-					Value:   service.Image,
-					Message: "Generated an internal image reference for the local build.",
-				})
-			}
+			report.Inferred = append(report.Inferred, model.ConversionDecision{
+				Path:    "services." + rawServiceName + ".image",
+				Value:   service.Image,
+				Message: "Generated an internal image reference for the local build.",
+			})
 		}
 	}
 
@@ -303,16 +393,16 @@ func completeConversionReport(report *model.ConversionReport, project types.Proj
 	sortConversionReport(report)
 }
 
-func findRawService(rawServices map[string]any, normalizedName string) map[string]any {
+func findRawService(rawServices map[string]any, normalizedName string) (string, map[string]any) {
 	for name, value := range rawServices {
 		normalized, err := normalizeName(name)
 		if err != nil || normalized != normalizedName {
 			continue
 		}
 		service, _ := asMap(value)
-		return service
+		return name, service
 	}
-	return nil
+	return normalizedName, nil
 }
 
 func addResourceDecisions(report *model.ConversionReport, project types.Project, app model.App) {

--- a/internal/compose/report_test.go
+++ b/internal/compose/report_test.go
@@ -39,6 +39,20 @@ x-uds:
 	}
 }
 
+func TestConvertCanonicalFileReadFailureIncludesRemediation(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalFile(filepath.Join(t.TempDir(), "missing-compose.yaml"))
+	if err == nil {
+		t.Fatal("ConvertCanonicalFile() error = nil, want read error")
+	}
+
+	rejected := requireDecision(t, conversion.Report.Rejected, "compose")
+	if rejected.Code != "read-error" || rejected.Remediation == "" {
+		t.Fatalf("rejected decision = %#v, want read-error with remediation", rejected)
+	}
+}
+
 func TestConvertCanonicalFileAlignsReportWithConsumedSettings(t *testing.T) {
 	t.Parallel()
 
@@ -361,6 +375,149 @@ services:
 	requireDecision(t, conversion.Report.Rejected, "services.api.depends_on.db")
 	if hasDecision(conversion.Report.Translated, "services.api.depends_on") {
 		t.Fatalf("translated decisions unexpectedly include rejected dependency: %#v", conversion.Report.Translated)
+	}
+}
+
+func TestConvertCanonicalYAMLRejectsDependencyWithOnlyUDPPort(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    depends_on:
+      - dns
+  dns:
+    image: docker.io/library/bind:9.20
+    expose:
+      - "53/udp"
+`))
+	if err == nil {
+		t.Fatal("ConvertCanonicalYAML() error = nil, want dependency TCP port rejection")
+	}
+
+	rejected := requireDecision(t, conversion.Report.Rejected, "services.api.depends_on.dns")
+	if rejected.Code != "dependency-port" {
+		t.Fatalf("rejected code = %q, want dependency-port", rejected.Code)
+	}
+}
+
+func TestConvertCanonicalYAMLReportsExcludedServiceReferenceAtExtensionPath(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    depends_on:
+      db:
+        condition: service_started
+        required: false
+  db:
+    image: docker.io/library/postgres:18
+x-uds:
+  spec:
+    network:
+      expose:
+        - service: db
+`))
+	if err == nil {
+		t.Fatal("ConvertCanonicalYAML() error = nil, want excluded service reference")
+	}
+
+	rejected := requireDecision(t, conversion.Report.Rejected, "x-uds.spec.network.expose")
+	if rejected.Code != "invalid-setting" || rejected.Remediation == "" {
+		t.Fatalf("rejected decision = %#v, want invalid-setting with remediation", rejected)
+	}
+	if hasDecision(conversion.Report.Translated, "x-uds.spec.network.expose") {
+		t.Fatalf("translated decisions unexpectedly include rejected extension path: %#v", conversion.Report.Translated)
+	}
+}
+
+func TestConvertCanonicalYAMLReportsBuildTagsAsIgnored(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    build:
+      context: .
+      tags:
+        - ghcr.io/acme/custom:latest
+`))
+	if err != nil {
+		t.Fatalf("ConvertCanonicalYAML() error = %v", err)
+	}
+
+	requireDecision(t, conversion.Report.Translated, "services.api.build.context")
+	requireDecision(t, conversion.Report.Ignored, "services.api.build.tags")
+	if hasDecision(conversion.Report.Translated, "services.api.build") {
+		t.Fatalf("translated decisions unexpectedly include broad build path: %#v", conversion.Report.Translated)
+	}
+}
+
+func TestConvertCanonicalYAMLEnvFileIsIgnoredInReport(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    env_file: .env
+`))
+	if err != nil {
+		t.Fatalf("ConvertCanonicalYAML() error = %v", err)
+	}
+
+	requireDecision(t, conversion.Report.Ignored, "services.api.env_file")
+	if hasDecision(conversion.Report.Translated, "services.api.env_file") {
+		t.Fatalf("translated decisions unexpectedly include env_file: %#v", conversion.Report.Translated)
+	}
+}
+
+func TestConvertCanonicalYAMLReportsSecurityOptPerValue(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    security_opt:
+      - seccomp:unconfined
+      - no-new-privileges:true
+`))
+	if err != nil {
+		t.Fatalf("ConvertCanonicalYAML() error = %v", err)
+	}
+
+	requireDecision(t, conversion.Report.Translated, "services.api.security_opt[0]")
+	requireDecision(t, conversion.Report.Ignored, "services.api.security_opt[1]")
+	if hasDecision(conversion.Report.Translated, "services.api.security_opt") {
+		t.Fatalf("translated decisions unexpectedly include broad security_opt path: %#v", conversion.Report.Translated)
+	}
+}
+
+func TestConvertCanonicalYAMLPortsTranslationExcludesGatewayClaim(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    ports:
+      - "8080:8080"
+x-uds:
+  spec:
+    network:
+      expose: []
+`))
+	if err != nil {
+		t.Fatalf("ConvertCanonicalYAML() error = %v", err)
+	}
+
+	decision := requireDecision(t, conversion.Report.Translated, "services.api.ports")
+	if decision.Target != "Kubernetes Service ports" {
+		t.Fatalf("ports target = %q, want Kubernetes Service ports", decision.Target)
 	}
 }
 

--- a/internal/compose/report_test.go
+++ b/internal/compose/report_test.go
@@ -128,6 +128,95 @@ x-uds:
 	}
 }
 
+func TestConvertCanonicalYAMLCompatibilityRejectionRemovesTranslatedNetwork(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    networks:
+      - custom
+networks:
+  custom:
+    driver_opts:
+      encrypted: "true"
+`))
+	if err == nil {
+		t.Fatal("ConvertCanonicalYAML() error = nil, want unsupported network options")
+	}
+
+	requireDecision(t, conversion.Report.Rejected, "networks.custom")
+	if hasDecision(conversion.Report.Translated, "networks.custom") {
+		t.Fatalf("translated decisions unexpectedly include rejected network path: %#v", conversion.Report.Translated)
+	}
+}
+
+func TestConvertCanonicalYAMLUnsupportedVolumeTypeIsNotTranslated(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    volumes:
+      - type: tmpfs
+        target: /tmp/cache
+`))
+	if err == nil {
+		t.Fatal("ConvertCanonicalYAML() error = nil, want unsupported volume type")
+	}
+
+	requireDecision(t, conversion.Report.Rejected, "services.api.volumes")
+	if hasDecision(conversion.Report.Translated, "services.api.volumes[0]") {
+		t.Fatalf("translated decisions unexpectedly include unsupported volume mount: %#v", conversion.Report.Translated)
+	}
+}
+
+func TestConvertCanonicalYAMLInvalidMetadataNameIsIgnoredAndInferred(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+x-uds:
+  metadata:
+    name:
+      bad: value
+`))
+	if err != nil {
+		t.Fatalf("ConvertCanonicalYAML() error = %v", err)
+	}
+
+	requireDecision(t, conversion.Report.Ignored, "x-uds.metadata.name")
+	requireDecision(t, conversion.Report.Inferred, "x-uds.metadata.name")
+	if hasDecision(conversion.Report.Translated, "x-uds.metadata.name") {
+		t.Fatalf("translated decisions unexpectedly include invalid metadata.name: %#v", conversion.Report.Translated)
+	}
+}
+
+func TestConvertCanonicalYAMLInferredExposeAlsoInfersSSO(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    ports:
+      - "8080:8080"
+`))
+	if err != nil {
+		t.Fatalf("ConvertCanonicalYAML() error = %v", err)
+	}
+
+	requireDecision(t, conversion.Report.Inferred, "x-uds.spec.network.expose")
+	sso := requireDecision(t, conversion.Report.Inferred, "x-uds.spec.sso")
+	if sso.Value != "api" {
+		t.Fatalf("inferred sso value = %q, want api", sso.Value)
+	}
+}
+
 func hasDecision(decisions []model.ConversionDecision, path string) bool {
 	for _, decision := range decisions {
 		if decision.Path == path {

--- a/internal/compose/report_test.go
+++ b/internal/compose/report_test.go
@@ -1,0 +1,149 @@
+package compose
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"defenseunicorns/uds-compose-bridge/internal/model"
+)
+
+func TestConvertCanonicalYAMLReportsStructuredInvalidUDSSetting(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+x-uds:
+  metadata:
+    version:
+      bad: value
+`))
+	if err == nil {
+		t.Fatal("ConvertCanonicalYAML() error = nil, want invalid x-uds.metadata.version")
+	}
+
+	rejected := requireDecision(t, conversion.Report.Rejected, "x-uds.metadata.version")
+	if rejected.Code != "invalid-setting" {
+		t.Fatalf("rejected code = %q, want invalid-setting", rejected.Code)
+	}
+	if rejected.Remediation == "" {
+		t.Fatalf("rejected remediation = %q, want non-empty remediation", rejected.Remediation)
+	}
+	if hasDecision(conversion.Report.Translated, "x-uds.metadata.version") {
+		t.Fatalf("translated decisions unexpectedly include rejected path: %#v", conversion.Report.Translated)
+	}
+	if hasDecision(conversion.Report.Rejected, "compose") {
+		t.Fatalf("rejected decisions unexpectedly include generic compose failure: %#v", conversion.Report.Rejected)
+	}
+}
+
+func TestConvertCanonicalFileAlignsReportWithConsumedSettings(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "compose.yaml")
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+	if err := os.WriteFile(inputPath, []byte(`name: demo
+services:
+  my_api:
+    build:
+      context: .
+    image: ghcr.io/acme/api:1.2.3
+    deploy:
+      resources:
+        limits:
+          cpus: "0.50"
+          memory: 512M
+          pids: 50
+        reservations:
+          cpus: "0.25"
+          memory: 256M
+        devices:
+          - capabilities: ["gpu"]
+x-uds:
+  metadata:
+    name: uds-package
+    version: 1.2.3
+    description: ignored
+  spec:
+    foo: ignored
+    network:
+      expose:
+        - service: my_api
+      foo: ignored
+    caBundle:
+      configMap:
+        name: bundle
+        key: ca.pem
+`), 0o644); err != nil {
+		t.Fatalf("write compose.yaml: %v", err)
+	}
+
+	conversion, err := ConvertCanonicalFile(inputPath)
+	if err != nil {
+		t.Fatalf("ConvertCanonicalFile() error = %v", err)
+	}
+
+	requireDecision(t, conversion.Report.Ignored, "name")
+	requireDecision(t, conversion.Report.Ignored, "services.my_api.image")
+	imageDecision := requireDecision(t, conversion.Report.Inferred, "services.my_api.image")
+	if imageDecision.Value != "zarf.internal/uds-package-my-api:1.2.3-uds.0" {
+		t.Fatalf("inferred image value = %q", imageDecision.Value)
+	}
+	if hasDecision(conversion.Report.Inferred, "services.my-api.image") {
+		t.Fatalf("inferred decisions unexpectedly use normalized raw service path: %#v", conversion.Report.Inferred)
+	}
+	if hasDecision(conversion.Report.Translated, "services.my_api.image") {
+		t.Fatalf("translated decisions unexpectedly include overridden build image: %#v", conversion.Report.Translated)
+	}
+
+	for _, path := range []string{
+		"services.my_api.deploy.resources.limits.cpus",
+		"services.my_api.deploy.resources.limits.memory",
+		"services.my_api.deploy.resources.reservations.cpus",
+		"services.my_api.deploy.resources.reservations.memory",
+		"x-uds.metadata.name",
+		"x-uds.metadata.version",
+		"x-uds.spec.network.expose",
+		"x-uds.spec.caBundle",
+	} {
+		requireDecision(t, conversion.Report.Translated, path)
+	}
+	if hasDecision(conversion.Report.Translated, "services.my_api.deploy.resources") {
+		t.Fatalf("translated decisions unexpectedly include broad deploy.resources entry: %#v", conversion.Report.Translated)
+	}
+
+	for _, path := range []string{
+		"services.my_api.deploy.resources.limits.pids",
+		"services.my_api.deploy.resources.devices",
+		"x-uds.metadata.description",
+		"x-uds.spec.foo",
+		"x-uds.spec.network.foo",
+	} {
+		requireDecision(t, conversion.Report.Ignored, path)
+	}
+}
+
+func hasDecision(decisions []model.ConversionDecision, path string) bool {
+	for _, decision := range decisions {
+		if decision.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+func requireDecision(t *testing.T, decisions []model.ConversionDecision, path string) model.ConversionDecision {
+	t.Helper()
+	for _, decision := range decisions {
+		if decision.Path == path {
+			return decision
+		}
+	}
+	t.Fatalf("decision path %q not found in %#v", path, decisions)
+	return model.ConversionDecision{}
+}

--- a/internal/compose/report_test.go
+++ b/internal/compose/report_test.go
@@ -217,6 +217,177 @@ services:
 	}
 }
 
+func TestConvertCanonicalYAMLInfersMonitorFromMetricsPort(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    ports:
+      - target: 9090
+        published: "9090"
+        name: metrics
+`))
+	if err != nil {
+		t.Fatalf("ConvertCanonicalYAML() error = %v", err)
+	}
+
+	monitor := requireDecision(t, conversion.Report.Inferred, "x-uds.spec.monitor")
+	if monitor.Value != "api" {
+		t.Fatalf("inferred monitor value = %q, want api", monitor.Value)
+	}
+}
+
+func TestConvertCanonicalYAMLExplicitExposeStillInfersSSO(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    ports:
+      - target: 9090
+        published: "9090"
+        name: metrics
+x-uds:
+  spec:
+    network:
+      expose:
+        - service: api
+`))
+	if err != nil {
+		t.Fatalf("ConvertCanonicalYAML() error = %v", err)
+	}
+
+	sso := requireDecision(t, conversion.Report.Inferred, "x-uds.spec.sso")
+	if sso.Value != "api" {
+		t.Fatalf("inferred sso value = %q, want api", sso.Value)
+	}
+}
+
+func TestConvertCanonicalYAMLExplicitEmptyExposeDisablesInference(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    ports:
+      - "8080:8080"
+x-uds:
+  spec:
+    network:
+      expose: []
+`))
+	if err != nil {
+		t.Fatalf("ConvertCanonicalYAML() error = %v", err)
+	}
+
+	requireDecision(t, conversion.Report.Translated, "x-uds.spec.network.expose")
+	if hasDecision(conversion.Report.Inferred, "x-uds.spec.network.expose") {
+		t.Fatalf("inferred decisions unexpectedly include explicitly disabled exposure: %#v", conversion.Report.Inferred)
+	}
+	if hasDecision(conversion.Report.Inferred, "x-uds.spec.sso") {
+		t.Fatalf("inferred decisions unexpectedly include SSO without an exposure: %#v", conversion.Report.Inferred)
+	}
+}
+
+func TestConvertCanonicalYAMLReportsInferredNetworkAllow(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+x-uds:
+  spec:
+    network:
+      allow:
+        - direction: Egress
+          remoteNamespace: logging
+`))
+	if err != nil {
+		t.Fatalf("ConvertCanonicalYAML() error = %v", err)
+	}
+
+	requireDecision(t, conversion.Report.Inferred, "x-uds.spec.network.allow")
+	requireDecision(t, conversion.Report.Translated, "x-uds.spec.network.allow")
+}
+
+func TestConvertCanonicalYAMLDoesNotTranslateExcludedOptionalDependency(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    depends_on:
+      db:
+        condition: service_started
+        required: false
+  db:
+    image: docker.io/library/postgres:18
+    ports:
+      - "5432"
+`))
+	if err != nil {
+		t.Fatalf("ConvertCanonicalYAML() error = %v", err)
+	}
+
+	path := "services.api.depends_on"
+	if hasDecision(conversion.Report.Translated, path) {
+		t.Fatalf("translated decisions unexpectedly include excluded dependency: %#v", conversion.Report.Translated)
+	}
+	requireDecision(t, conversion.Report.Ignored, path)
+}
+
+func TestConvertCanonicalYAMLRejectsDependencyWithoutPort(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    depends_on:
+      - db
+  db:
+    image: docker.io/library/postgres:18
+`))
+	if err == nil {
+		t.Fatal("ConvertCanonicalYAML() error = nil, want dependency port rejection")
+	}
+
+	requireDecision(t, conversion.Report.Rejected, "services.api.depends_on.db")
+	if hasDecision(conversion.Report.Translated, "services.api.depends_on") {
+		t.Fatalf("translated decisions unexpectedly include rejected dependency: %#v", conversion.Report.Translated)
+	}
+}
+
+func TestConvertCanonicalYAMLNestedRejectionRemovesParentTranslation(t *testing.T) {
+	t.Parallel()
+
+	conversion, err := ConvertCanonicalYAML([]byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    networks:
+      custom:
+        aliases:
+          - backend
+networks:
+  custom: {}
+`))
+	if err == nil {
+		t.Fatal("ConvertCanonicalYAML() error = nil, want network options rejection")
+	}
+
+	requireDecision(t, conversion.Report.Rejected, "services.api.networks.custom")
+	if hasDecision(conversion.Report.Translated, "services.api.networks") {
+		t.Fatalf("translated decisions unexpectedly include rejected parent path: %#v", conversion.Report.Translated)
+	}
+}
+
 func hasDecision(decisions []model.ConversionDecision, path string) bool {
 	for _, decision := range decisions {
 		if decision.Path == path {

--- a/internal/inference/inference.go
+++ b/internal/inference/inference.go
@@ -1,0 +1,86 @@
+package inference
+
+import (
+	"strconv"
+	"strings"
+
+	"defenseunicorns/uds-compose-bridge/internal/model"
+)
+
+var wellKnownMetricsPorts = map[int]struct{}{
+	9090: {}, // Prometheus
+	9100: {}, // Prometheus Node Exporter
+	9115: {}, // Prometheus Blackbox Exporter
+	9121: {}, // Prometheus Redis Exporter
+	9153: {}, // CoreDNS metrics
+	9187: {}, // Prometheus PostgreSQL Exporter
+	9256: {}, // Prometheus Process Exporter
+}
+
+// MetricsPorts returns the service ports that imply generated monitor entries.
+func MetricsPorts(service model.Service) []model.Port {
+	environmentPorts := metricsEnvironmentPorts(service.Env)
+	ports := make([]model.Port, 0, len(service.Ports))
+	for _, port := range service.Ports {
+		if !strings.EqualFold(port.Protocol, "TCP") {
+			continue
+		}
+		_, wellKnown := wellKnownMetricsPorts[port.Number]
+		_, configuredByEnvironment := environmentPorts[port.Number]
+		if isMetricsPortName(port.Name) || wellKnown || configuredByEnvironment {
+			ports = append(ports, port)
+		}
+	}
+	return ports
+}
+
+// PrimaryExposedService returns the host and service used for inferred SSO.
+func PrimaryExposedService(app model.App) (host string, service string) {
+	if app.Package.NetworkExposeConfigured {
+		for _, raw := range app.Package.NetworkExpose {
+			if item, ok := raw.(map[string]any); ok {
+				host, _ = item["host"].(string)
+				service, _ = item["service"].(string)
+				if host == "" {
+					host = service
+				}
+				return host, service
+			}
+		}
+		return "", ""
+	}
+	for _, candidate := range app.Services {
+		for _, port := range candidate.Ports {
+			if port.Published {
+				return candidate.Name, candidate.Name
+			}
+		}
+	}
+	return "", ""
+}
+
+func isMetricsPortName(name string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	normalized = strings.ReplaceAll(normalized, "_", "-")
+	for _, token := range strings.Split(normalized, "-") {
+		if token == "metrics" || token == "prometheus" {
+			return true
+		}
+	}
+	return false
+}
+
+func metricsEnvironmentPorts(environment []model.EnvVar) map[int]struct{} {
+	ports := map[int]struct{}{}
+	for _, item := range environment {
+		name := strings.ToUpper(strings.TrimSpace(item.Name))
+		if name != "METRICS_PORT" && name != "PROMETHEUS_PORT" {
+			continue
+		}
+		port, err := strconv.Atoi(strings.TrimSpace(item.Value))
+		if err == nil && port > 0 && port <= 65535 {
+			ports[port] = struct{}{}
+		}
+	}
+	return ports
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -95,21 +95,22 @@ type Dependency struct {
 }
 
 type Package struct {
-	Name              string
-	Namespace         string
-	Group             string
-	UpstreamVersion   string
-	Version           string
-	VersionConfigured bool
-	Labels            map[string]string
-	Annotations       map[string]string
-	NetworkExpose     []any
-	MonitorConfigured bool
-	Monitor           []any
-	AdditionalAllow   []any
-	SSOConfigured     bool
-	SSO               []any
-	CABundle          map[string]any
+	Name                    string
+	Namespace               string
+	Group                   string
+	UpstreamVersion         string
+	Version                 string
+	VersionConfigured       bool
+	Labels                  map[string]string
+	Annotations             map[string]string
+	NetworkExposeConfigured bool
+	NetworkExpose           []any
+	MonitorConfigured       bool
+	Monitor                 []any
+	AdditionalAllow         []any
+	SSOConfigured           bool
+	SSO                     []any
+	CABundle                map[string]any
 }
 
 type BuildDefinition struct {
@@ -168,6 +169,37 @@ type ConversionReport struct {
 	Inferred   []ConversionDecision `json:"inferred"`
 	Ignored    []ConversionDecision `json:"ignored"`
 	Rejected   []ConversionDecision `json:"rejected"`
+}
+
+// RemoveConflictingTranslated removes translated decisions that overlap a
+// rejected setting at the same path or at a parent or child path.
+func (r *ConversionReport) RemoveConflictingTranslated(decisions []ConversionDecision) {
+	filtered := r.Translated[:0]
+	for _, translated := range r.Translated {
+		conflict := false
+		for _, decision := range decisions {
+			if decisionPathsOverlap(translated.Path, decision.Path) {
+				conflict = true
+				break
+			}
+		}
+		if !conflict {
+			filtered = append(filtered, translated)
+		}
+	}
+	r.Translated = filtered
+}
+
+func decisionPathsOverlap(left, right string) bool {
+	return left == right || decisionPathContains(left, right) || decisionPathContains(right, left)
+}
+
+func decisionPathContains(parent, child string) bool {
+	if !strings.HasPrefix(child, parent) || len(child) == len(parent) {
+		return false
+	}
+	separator := child[len(parent)]
+	return separator == '.' || separator == '['
 }
 
 type Conversion struct {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -154,6 +154,27 @@ type App struct {
 	BuildSecrets map[string]any
 }
 
+type ConversionDecision struct {
+	Path        string `json:"path"`
+	Target      string `json:"target,omitempty"`
+	Value       string `json:"value,omitempty"`
+	Code        string `json:"code,omitempty"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+type ConversionReport struct {
+	Translated []ConversionDecision `json:"translated"`
+	Inferred   []ConversionDecision `json:"inferred"`
+	Ignored    []ConversionDecision `json:"ignored"`
+	Rejected   []ConversionDecision `json:"rejected"`
+}
+
+type Conversion struct {
+	App    App
+	Report ConversionReport
+}
+
 func (s Service) PrimaryPort() (Port, error) {
 	if len(s.Ports) == 0 {
 		return Port{}, fmt.Errorf("service %q has no declared ports", s.Name)

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -84,14 +84,49 @@ func WriteConversion(root string, conversion model.Conversion) error {
 		return err
 	}
 	if err := writePackage(root, conversion.App, true); err != nil {
-		conversion.Report.Rejected = append(conversion.Report.Rejected, model.ConversionDecision{
-			Path:    "package",
-			Code:    "package-generation",
-			Message: err.Error(),
-		})
+		if decisions := renderFailureDecisions(err); len(decisions) > 0 {
+			removeConflictingTranslatedDecisions(&conversion.Report, decisions)
+			conversion.Report.Rejected = append(conversion.Report.Rejected, decisions...)
+		} else {
+			conversion.Report.Rejected = append(conversion.Report.Rejected, model.ConversionDecision{
+				Path:    "package",
+				Code:    "package-generation",
+				Message: err.Error(),
+			})
+		}
 		return errors.Join(err, WriteConversionReport(root, conversion.Report))
 	}
 	return nil
+}
+
+var monitorRenderFailurePattern = regexp.MustCompile(`^x-uds\.spec\.monitor(?:\b| )`)
+
+func renderFailureDecisions(err error) []model.ConversionDecision {
+	message := err.Error()
+	if monitorRenderFailurePattern.MatchString(message) {
+		return []model.ConversionDecision{{
+			Path:        "x-uds.spec.monitor",
+			Code:        "invalid-setting",
+			Message:     message,
+			Remediation: "ensure each monitor entry references a Compose service and valid service port settings",
+		}}
+	}
+	return nil
+}
+
+func removeConflictingTranslatedDecisions(report *model.ConversionReport, decisions []model.ConversionDecision) {
+	paths := make(map[string]struct{}, len(decisions))
+	for _, decision := range decisions {
+		paths[decision.Path] = struct{}{}
+	}
+	filtered := report.Translated[:0]
+	for _, decision := range report.Translated {
+		if _, conflict := paths[decision.Path]; conflict {
+			continue
+		}
+		filtered = append(filtered, decision)
+	}
+	report.Translated = filtered
 }
 
 func writePackage(root string, app model.App, includeConversionReport bool) error {

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -90,9 +90,10 @@ func WriteConversion(root string, conversion model.Conversion) error {
 			conversion.Report.Rejected = append(conversion.Report.Rejected, decisions...)
 		} else {
 			conversion.Report.Rejected = append(conversion.Report.Rejected, model.ConversionDecision{
-				Path:    "package",
-				Code:    "package-generation",
-				Message: err.Error(),
+				Path:        "package",
+				Code:        "package-generation",
+				Message:     err.Error(),
+				Remediation: "address the reported package-generation error and rerun conversion",
 			})
 		}
 		return errors.Join(err, WriteConversionReport(root, conversion.Report))
@@ -216,8 +217,8 @@ func writePackage(root string, app model.App, includeConversionReport bool) erro
 	preserveNetworkMembership := hasDistinctNetworkMemberships(app.Services)
 	servicePorts := map[string]int{}
 	for _, svc := range app.Services {
-		if len(svc.Ports) > 0 {
-			servicePorts[svc.Name] = svc.Ports[0].Number
+		if port, ok := primaryDependencyWaitPort(svc.Ports); ok {
+			servicePorts[svc.Name] = port
 		}
 	}
 
@@ -1735,6 +1736,18 @@ func titleCase(name string) string {
 
 func primaryPublishedPort(ports []model.Port) (model.Port, bool) {
 	return primaryGatewayPort(ports, true)
+}
+
+func primaryDependencyWaitPort(ports []model.Port) (int, bool) {
+	for _, port := range ports {
+		if port.Number <= 0 {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(port.Protocol), "TCP") {
+			return port.Number, true
+		}
+	}
+	return 0, false
 }
 
 func primaryGatewayPort(ports []model.Port, requirePublished bool) (model.Port, bool) {

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -14,6 +14,7 @@ import (
 
 	yamlv3 "gopkg.in/yaml.v3"
 
+	"defenseunicorns/uds-compose-bridge/internal/inference"
 	"defenseunicorns/uds-compose-bridge/internal/model"
 )
 
@@ -84,8 +85,8 @@ func WriteConversion(root string, conversion model.Conversion) error {
 		return err
 	}
 	if err := writePackage(root, conversion.App, true); err != nil {
-		if decisions := renderFailureDecisions(err); len(decisions) > 0 {
-			removeConflictingTranslatedDecisions(&conversion.Report, decisions)
+		if decisions := renderFailureDecisions(err, conversion.Report); len(decisions) > 0 {
+			conversion.Report.RemoveConflictingTranslated(decisions)
 			conversion.Report.Rejected = append(conversion.Report.Rejected, decisions...)
 		} else {
 			conversion.Report.Rejected = append(conversion.Report.Rejected, model.ConversionDecision{
@@ -101,8 +102,28 @@ func WriteConversion(root string, conversion model.Conversion) error {
 
 var monitorRenderFailurePattern = regexp.MustCompile(`^x-uds\.spec\.monitor(?:\b| )`)
 
-func renderFailureDecisions(err error) []model.ConversionDecision {
+type settingError struct {
+	path        string
+	code        string
+	message     string
+	remediation string
+}
+
+func (e *settingError) Error() string {
+	return e.message
+}
+
+func renderFailureDecisions(err error, report model.ConversionReport) []model.ConversionDecision {
 	message := err.Error()
+	var sourceErr *settingError
+	if errors.As(err, &sourceErr) {
+		return []model.ConversionDecision{{
+			Path:        reportedSourcePath(report, sourceErr.path),
+			Code:        sourceErr.code,
+			Message:     sourceErr.message,
+			Remediation: sourceErr.remediation,
+		}}
+	}
 	if monitorRenderFailurePattern.MatchString(message) {
 		return []model.ConversionDecision{{
 			Path:        "x-uds.spec.monitor",
@@ -114,19 +135,59 @@ func renderFailureDecisions(err error) []model.ConversionDecision {
 	return nil
 }
 
-func removeConflictingTranslatedDecisions(report *model.ConversionReport, decisions []model.ConversionDecision) {
-	paths := make(map[string]struct{}, len(decisions))
-	for _, decision := range decisions {
-		paths[decision.Path] = struct{}{}
-	}
-	filtered := report.Translated[:0]
+func reportedSourcePath(report model.ConversionReport, path string) string {
 	for _, decision := range report.Translated {
-		if _, conflict := paths[decision.Path]; conflict {
-			continue
+		if decision.Path == path || equivalentServiceSettingPath(decision.Path, path) || equivalentResourcePath(decision.Path, path) {
+			return decision.Path
 		}
-		filtered = append(filtered, decision)
+		if servicePath, ok := equivalentServicePath(decision.Path, path); ok {
+			return servicePath
+		}
 	}
-	report.Translated = filtered
+	return path
+}
+
+func equivalentServicePath(decisionPath, sourcePath string) (string, bool) {
+	const prefix = "services."
+	if !strings.HasPrefix(decisionPath, prefix) || !strings.HasPrefix(sourcePath, prefix) {
+		return "", false
+	}
+	decisionEnd := strings.LastIndex(decisionPath, ".")
+	if decisionEnd <= len(prefix) {
+		return "", false
+	}
+	rawServiceName := decisionPath[len(prefix):decisionEnd]
+	sourceServiceName := strings.TrimPrefix(sourcePath, prefix)
+	if normalizedSourceName(rawServiceName) != normalizedSourceName(sourceServiceName) {
+		return "", false
+	}
+	return prefix + rawServiceName, true
+}
+
+func equivalentServiceSettingPath(left, right string) bool {
+	const prefix = "services."
+	if !strings.HasPrefix(left, prefix) || !strings.HasPrefix(right, prefix) {
+		return false
+	}
+	leftEnd := strings.LastIndex(left, ".")
+	rightEnd := strings.LastIndex(right, ".")
+	if leftEnd <= len(prefix) || rightEnd <= len(prefix) || left[leftEnd:] != right[rightEnd:] {
+		return false
+	}
+	return normalizedSourceName(left[len(prefix):leftEnd]) == normalizedSourceName(right[len(prefix):rightEnd])
+}
+
+func equivalentResourcePath(left, right string) bool {
+	for _, prefix := range []string{"configs.", "secrets.", "volumes."} {
+		if strings.HasPrefix(left, prefix) && strings.HasPrefix(right, prefix) {
+			return normalizedSourceName(strings.TrimPrefix(left, prefix)) == normalizedSourceName(strings.TrimPrefix(right, prefix))
+		}
+	}
+	return false
+}
+
+func normalizedSourceName(value string) string {
+	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(value)), "_", "-")
 }
 
 func writePackage(root string, app model.App, includeConversionReport bool) error {
@@ -1188,7 +1249,7 @@ func buildUDSPackage(app model.App) (udsPackageManifest, error) {
 
 	// --- Expose rules ---
 	var expose []any
-	if len(app.Package.NetworkExpose) > 0 {
+	if app.Package.NetworkExposeConfigured {
 		expose = enrichNetworkExposes(app)
 	} else {
 		expose = buildAutoExposes(app)
@@ -1424,20 +1485,10 @@ func buildMonitor(app model.App) ([]any, error) {
 	return enriched, nil
 }
 
-var wellKnownMetricsPorts = map[int]struct{}{
-	9090: {}, // Prometheus
-	9100: {}, // Prometheus Node Exporter
-	9115: {}, // Prometheus Blackbox Exporter
-	9121: {}, // Prometheus Redis Exporter
-	9153: {}, // CoreDNS metrics
-	9187: {}, // Prometheus PostgreSQL Exporter
-	9256: {}, // Prometheus Process Exporter
-}
-
 func buildInferredMonitors(app model.App) []any {
 	var monitors []any
 	for _, svc := range app.Services {
-		metricsPorts := inferredMetricsPorts(svc)
+		metricsPorts := inference.MetricsPorts(svc)
 		for _, port := range metricsPorts {
 			selector := serviceSelector(svc.Name)
 			monitors = append(monitors, map[string]any{
@@ -1452,48 +1503,6 @@ func buildInferredMonitors(app model.App) []any {
 		}
 	}
 	return monitors
-}
-
-func inferredMetricsPorts(svc model.Service) []model.Port {
-	environmentPorts := metricsEnvironmentPorts(svc.Env)
-	ports := make([]model.Port, 0, len(svc.Ports))
-	for _, port := range svc.Ports {
-		if !strings.EqualFold(port.Protocol, "TCP") {
-			continue
-		}
-		_, wellKnown := wellKnownMetricsPorts[port.Number]
-		_, configuredByEnvironment := environmentPorts[port.Number]
-		if isMetricsPortName(port.Name) || wellKnown || configuredByEnvironment {
-			ports = append(ports, port)
-		}
-	}
-	return ports
-}
-
-func isMetricsPortName(name string) bool {
-	normalized := strings.ToLower(strings.TrimSpace(name))
-	normalized = strings.ReplaceAll(normalized, "_", "-")
-	for _, token := range strings.Split(normalized, "-") {
-		if token == "metrics" || token == "prometheus" {
-			return true
-		}
-	}
-	return false
-}
-
-func metricsEnvironmentPorts(environment []model.EnvVar) map[int]struct{} {
-	ports := map[int]struct{}{}
-	for _, item := range environment {
-		name := strings.ToUpper(strings.TrimSpace(item.Name))
-		if name != "METRICS_PORT" && name != "PROMETHEUS_PORT" {
-			continue
-		}
-		port, err := strconv.Atoi(strings.TrimSpace(item.Value))
-		if err == nil && port > 0 && port <= 65535 {
-			ports[port] = struct{}{}
-		}
-	}
-	return ports
 }
 
 func enrichMonitorPortFields(entry map[string]any, svc model.Service) error {
@@ -1651,7 +1660,7 @@ func lookupRawInt(values map[string]any, key string) (int, bool) {
 
 // buildInferredSSO generates a default SSO client from the app's expose rules.
 func buildInferredSSO(app model.App) []any {
-	host, service := findPrimaryExposedService(app)
+	host, service := inference.PrimaryExposedService(app)
 	if host == "" {
 		return nil
 	}
@@ -1671,7 +1680,7 @@ func buildInferredSSO(app model.App) []any {
 
 // enrichSSOEntries fills in missing fields on user-provided x-uds.spec.sso entries.
 func enrichSSOEntries(app model.App) []any {
-	host, service := findPrimaryExposedService(app)
+	host, service := inference.PrimaryExposedService(app)
 	enriched := make([]any, 0, len(app.Package.SSO))
 
 	for _, raw := range app.Package.SSO {
@@ -1711,28 +1720,6 @@ func inferredSSOName(pkg model.Package) string {
 
 func inferredRedirectURI(host string) string {
 	return fmt.Sprintf("https://%s.%s/*", host, helmDomainValue)
-}
-
-// findPrimaryExposedService determines the primary host and service name from expose rules.
-func findPrimaryExposedService(app model.App) (host string, service string) {
-	if len(app.Package.NetworkExpose) > 0 {
-		for _, raw := range app.Package.NetworkExpose {
-			if item, ok := raw.(map[string]any); ok {
-				h, _ := item["host"].(string)
-				s, _ := item["service"].(string)
-				if h == "" {
-					h = s
-				}
-				return h, s
-			}
-		}
-	}
-	for _, svc := range app.Services {
-		if _, ok := primaryPublishedPort(svc.Ports); ok {
-			return svc.Name, svc.Name
-		}
-	}
-	return "", ""
 }
 
 // titleCase converts a hyphenated name to Title Case (e.g. "hello-world" → "Hello World").
@@ -2140,14 +2127,18 @@ func buildEnvironmentVariables(
 	secretVariables map[string]secretVariableNames,
 	configVariables map[string]configVariableNames,
 ) (map[string]map[string]string, error) {
-	usedVariables := map[string]string{
-		additionalNetworkAllowVariable: fmt.Sprintf("automatic package variable %q", additionalNetworkAllowVariable),
-		domainVariable:                 fmt.Sprintf("automatic package variable %q", domainVariable),
+	usedVariables := map[string]variableOwner{
+		additionalNetworkAllowVariable: {description: fmt.Sprintf("automatic package variable %q", additionalNetworkAllowVariable), path: "package"},
+		domainVariable:                 {description: fmt.Sprintf("automatic package variable %q", domainVariable), path: "package"},
 	}
 	for _, svc := range app.Services {
 		resourceVariables := buildResourceVariableNames(svc.Name)
 		for _, name := range resourceVariables.all() {
-			if err := registerZarfVariable(usedVariables, name, fmt.Sprintf("automatic resource variable for service %q", svc.Name)); err != nil {
+			owner := variableOwner{
+				description: fmt.Sprintf("automatic resource variable for service %q", svc.Name),
+				path:        "services." + svc.Name,
+			}
+			if err := registerZarfVariable(usedVariables, name, owner); err != nil {
 				return nil, err
 			}
 		}
@@ -2161,7 +2152,7 @@ func buildEnvironmentVariables(
 			if err := registerZarfVariable(
 				usedVariables,
 				name,
-				fmt.Sprintf("compose secret %q", secretName),
+				variableOwner{description: fmt.Sprintf("compose secret %q", secretName), path: "secrets." + secretName},
 			); err != nil {
 				return nil, err
 			}
@@ -2177,7 +2168,7 @@ func buildEnvironmentVariables(
 			if err := registerZarfVariable(
 				usedVariables,
 				name,
-				fmt.Sprintf("compose config %q", configName),
+				variableOwner{description: fmt.Sprintf("compose config %q", configName), path: "configs." + configName},
 			); err != nil {
 				return nil, err
 			}
@@ -2199,26 +2190,35 @@ func buildEnvironmentVariables(
 		}
 		configMapName := environmentConfigMapName(svc.Name)
 		if composeConfig, exists := renderedConfigMaps[configMapName]; exists {
-			return nil, fmt.Errorf(
-				"environment ConfigMap %q for service %q conflicts with compose config %q",
-				configMapName,
-				svc.Name,
-				composeConfig,
-			)
+			message := fmt.Sprintf("environment ConfigMap %q for service %q conflicts with compose config %q", configMapName, svc.Name, composeConfig)
+			return nil, &settingError{
+				path:        "services." + svc.Name + ".environment",
+				code:        "environment-configmap-conflict",
+				message:     message,
+				remediation: "rename the Compose config or service so their generated ConfigMap names are distinct",
+			}
 		}
 
 		serviceVariables := map[string]string{}
 		for _, item := range svc.Env {
 			if !kubernetesEnvironmentName.MatchString(item.Name) {
-				return nil, fmt.Errorf(
-					"invalid environment variable %q on service %q: names used with generated envFrom ConfigMaps must match %s",
+				message := fmt.Sprintf("invalid environment variable %q on service %q: names used with generated envFrom ConfigMaps must match %s",
 					item.Name,
 					svc.Name,
 					kubernetesEnvironmentName.String(),
 				)
+				return nil, &settingError{
+					path:        "services." + svc.Name + ".environment",
+					code:        "environment-name",
+					message:     message,
+					remediation: "rename the environment variable to a valid Kubernetes environment name",
+				}
 			}
 			variableName := normalizeZarfVariableName(svc.Name + "_" + item.Name)
-			owner := fmt.Sprintf("environment variable %q on service %q", item.Name, svc.Name)
+			owner := variableOwner{
+				description: fmt.Sprintf("environment variable %q on service %q", item.Name, svc.Name),
+				path:        "services." + svc.Name + ".environment",
+			}
 			if err := registerZarfVariable(usedVariables, variableName, owner); err != nil {
 				return nil, err
 			}
@@ -2229,22 +2229,39 @@ func buildEnvironmentVariables(
 	return out, nil
 }
 
-func registerZarfVariable(used map[string]string, name, owner string) error {
+type variableOwner struct {
+	description string
+	path        string
+}
+
+func registerZarfVariable(used map[string]variableOwner, name string, owner variableOwner) error {
 	if !validZarfVariableName.MatchString(name) {
-		return fmt.Errorf(
+		message := fmt.Sprintf(
 			"%s generates invalid Zarf variable %q: names must match %s",
-			owner,
+			owner.description,
 			name,
 			validZarfVariableName.String(),
 		)
+		return &settingError{
+			path:        owner.path,
+			code:        "zarf-variable-name",
+			message:     message,
+			remediation: "rename the source setting so it generates a valid and unique Zarf variable name",
+		}
 	}
 	if existing, exists := used[name]; exists {
-		return fmt.Errorf(
+		message := fmt.Sprintf(
 			"%s generates Zarf variable %q, which conflicts with %s",
-			owner,
+			owner.description,
 			name,
-			existing,
+			existing.description,
 		)
+		return &settingError{
+			path:        owner.path,
+			code:        "zarf-variable-conflict",
+			message:     message,
+			remediation: "rename the source setting so generated Zarf variable names are unique",
+		}
 	}
 	used[name] = owner
 	return nil
@@ -2365,13 +2382,19 @@ func validatePortNames(services []model.Service) error {
 		for _, port := range svc.Ports {
 			name := buildPortName(port)
 			if previous, exists := seen[name]; exists {
-				return fmt.Errorf(
+				message := fmt.Sprintf(
 					"service %q ports %s and %s resolve to duplicate Kubernetes port name %q",
 					svc.Name,
 					formatPortNameSource(previous),
 					formatPortNameSource(port),
 					name,
 				)
+				return &settingError{
+					path:        "services." + svc.Name + ".ports",
+					code:        "duplicate-port-name",
+					message:     message,
+					remediation: "set distinct Compose port names that remain unique after Kubernetes normalization",
+				}
 			}
 			seen[name] = port
 		}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -3,6 +3,7 @@ package render
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -75,6 +76,25 @@ const externalResourceHelpers = `{{- define "composeBridge.externalResourceName"
 `
 
 func WritePackage(root string, app model.App) error {
+	return writePackage(root, app, false)
+}
+
+func WriteConversion(root string, conversion model.Conversion) error {
+	if err := WriteConversionReport(root, conversion.Report); err != nil {
+		return err
+	}
+	if err := writePackage(root, conversion.App, true); err != nil {
+		conversion.Report.Rejected = append(conversion.Report.Rejected, model.ConversionDecision{
+			Path:    "package",
+			Code:    "package-generation",
+			Message: err.Error(),
+		})
+		return errors.Join(err, WriteConversionReport(root, conversion.Report))
+	}
+	return nil
+}
+
+func writePackage(root string, app model.App, includeConversionReport bool) error {
 	if err := validatePortNames(app.Services); err != nil {
 		return err
 	}
@@ -255,7 +275,7 @@ func WritePackage(root string, app model.App) error {
 		return err
 	}
 
-	if err := writeZarfConfig(filepath.Join(root, "zarf.yaml"), app, secretVariables, configVariables, environmentVariables, images, flavor); err != nil {
+	if err := writeZarfConfig(filepath.Join(root, "zarf.yaml"), app, secretVariables, configVariables, environmentVariables, images, flavor, includeConversionReport); err != nil {
 		return err
 	}
 
@@ -838,6 +858,7 @@ func writeZarfConfig(
 	environmentVariables map[string]map[string]string,
 	images []string,
 	flavor string,
+	includeConversionReport bool,
 ) error {
 	variables := []zarfVariable{
 		{
@@ -930,6 +951,9 @@ func writeZarfConfig(
 			"configuration": "docs/configuration.md",
 			"dependencies":  "docs/dependencies.md",
 		},
+	}
+	if includeConversionReport {
+		pkg.Documentation["conversion"] = "docs/conversion.md"
 	}
 
 	chart := zarfChart{

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -3357,6 +3357,7 @@ services:
         condition: service_healthy
   database:
     image: postgres:17
+    expose: ["5432"]
 secrets:
   api_key:
     file: ./api_key.txt
@@ -4345,6 +4346,43 @@ services:
 	}
 	if got := expose["host"]; got != "custom-api" {
 		t.Fatalf("expose host = %#v, want custom-api", got)
+	}
+}
+
+func TestWritePackageExplicitEmptyNetworkExposeDisablesInference(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: demo
+x-uds:
+  spec:
+    network:
+      expose: []
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    ports:
+      - target: 8080
+        published: "8080"
+        protocol: tcp
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	udsPackage := readUDSPackageYAMLMap(t, filepath.Join(outDir, "chart", "templates", "uds-package.yaml"))
+	spec := mustMap(t, udsPackage["spec"])
+	network := mustMap(t, spec["network"])
+	if _, exists := network["expose"]; exists {
+		t.Fatalf("network expose = %#v, want omitted", network["expose"])
+	}
+	if _, exists := spec["sso"]; exists {
+		t.Fatalf("sso = %#v, want omitted without an exposure", spec["sso"])
 	}
 }
 

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -982,6 +982,37 @@ services:
 	}
 }
 
+func TestWritePackageDependencyWaitUsesTCPPort(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    depends_on: [dns]
+  dns:
+    image: ghcr.io/acme/dns:1.0.0
+    expose: ["53/udp", "5353/tcp"]
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	deployment := readFile(t, filepath.Join(outDir, "chart", "templates", "deployment-api.yaml"))
+	if !strings.Contains(deployment, "nc -z dns 5353") {
+		t.Fatalf("expected dependency wait to use declared TCP port\n%s", deployment)
+	}
+	if strings.Contains(deployment, "nc -z dns 53;") {
+		t.Fatalf("expected dependency wait to skip UDP-only port\n%s", deployment)
+	}
+}
+
 func TestLoadCanonicalRejectsXUDSReferenceToExcludedService(t *testing.T) {
 	t.Parallel()
 

--- a/internal/render/report.go
+++ b/internal/render/report.go
@@ -1,0 +1,96 @@
+package render
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"defenseunicorns/uds-compose-bridge/internal/model"
+)
+
+func WriteConversionReport(root string, report model.ConversionReport) error {
+	docsDir := filepath.Join(root, "docs")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		return fmt.Errorf("create conversion report directory %s: %w", docsDir, err)
+	}
+
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode conversion report: %w", err)
+	}
+	data = append(data, '\n')
+	jsonPath := filepath.Join(root, "conversion.json")
+	if err := os.WriteFile(jsonPath, data, 0o644); err != nil {
+		return fmt.Errorf("write conversion report %s: %w", jsonPath, err)
+	}
+
+	markdownPath := filepath.Join(docsDir, "conversion.md")
+	if err := os.WriteFile(markdownPath, []byte(buildConversionMarkdown(report)), 0o644); err != nil {
+		return fmt.Errorf("write conversion report %s: %w", markdownPath, err)
+	}
+	return nil
+}
+
+func buildConversionMarkdown(report model.ConversionReport) string {
+	var content strings.Builder
+	content.WriteString("# Conversion Report\n\n")
+	content.WriteString("This report records how settings from the Compose model were handled during UDS package conversion.\n\n")
+	writeDecisionSection(&content, "Translated settings", report.Translated, false)
+	writeDecisionSection(&content, "Inferred settings", report.Inferred, false)
+	writeDecisionSection(&content, "Ignored settings", report.Ignored, false)
+	writeDecisionSection(&content, "Rejected settings", report.Rejected, true)
+	return content.String()
+}
+
+func writeDecisionSection(content *strings.Builder, title string, decisions []model.ConversionDecision, rejected bool) {
+	fmt.Fprintf(content, "## %s\n\n", title)
+	if len(decisions) == 0 {
+		content.WriteString("None.\n\n")
+		return
+	}
+
+	if rejected {
+		content.WriteString("| Setting | Code | Message | Remediation |\n")
+		content.WriteString("| --- | --- | --- | --- |\n")
+		for _, decision := range decisions {
+			fmt.Fprintf(content, "| `%s` | `%s` | %s | %s |\n",
+				markdownReportValue(decision.Path),
+				markdownReportValue(decision.Code),
+				markdownReportValue(decision.Message),
+				markdownReportValue(decision.Remediation),
+			)
+		}
+		content.WriteString("\n")
+		return
+	}
+
+	content.WriteString("| Setting | Result | Details |\n")
+	content.WriteString("| --- | --- | --- |\n")
+	for _, decision := range decisions {
+		result := decision.Target
+		if decision.Value != "" {
+			if result != "" {
+				result += ": "
+			}
+			result += decision.Value
+		}
+		fmt.Fprintf(content, "| `%s` | %s | %s |\n",
+			markdownReportValue(decision.Path),
+			markdownReportValue(result),
+			markdownReportValue(decision.Message),
+		)
+	}
+	content.WriteString("\n")
+}
+
+func markdownReportValue(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	value = strings.ReplaceAll(value, "|", "\\|")
+	value = strings.ReplaceAll(value, "\r\n", "<br>")
+	value = strings.ReplaceAll(value, "\n", "<br>")
+	return value
+}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -17,14 +18,17 @@ func main() {
 	flag.StringVar(&output, "out", "/out", "Output directory for the generated UDS package")
 	flag.Parse()
 
-	app, err := compose.LoadCanonicalFile(input)
-	if err != nil {
+	if err := run(input, output); err != nil {
 		fail(err)
 	}
+}
 
-	if err := render.WritePackage(output, app); err != nil {
-		fail(err)
+func run(input, output string) error {
+	conversion, conversionErr := compose.ConvertCanonicalFile(input)
+	if conversionErr != nil {
+		return errors.Join(conversionErr, render.WriteConversionReport(output, conversion.Report))
 	}
+	return render.WriteConversion(output, conversion)
 }
 
 func fail(err error) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"defenseunicorns/uds-compose-bridge/internal/model"
+)
+
+func TestRunWritesConversionReports(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "compose.yaml")
+	outputPath := filepath.Join(dir, "out")
+	input := []byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    container_name: custom-api
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./data:/app/data
+`)
+	if err := os.WriteFile(inputPath, input, 0o644); err != nil {
+		t.Fatalf("write Compose input: %v", err)
+	}
+
+	if err := run(inputPath, outputPath); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+
+	report := readConversionReport(t, filepath.Join(outputPath, "conversion.json"))
+	assertDecisionPath(t, report.Translated, "services.api.image")
+	assertDecisionPath(t, report.Inferred, "x-uds.metadata.name")
+	assertDecisionPath(t, report.Inferred, "x-uds.metadata.version")
+	assertDecisionPath(t, report.Ignored, "services.api.container_name")
+	assertDecisionPath(t, report.Ignored, "services.api.volumes[0]")
+	for _, decision := range report.Inferred {
+		if !strings.HasPrefix(decision.Path, "services.") &&
+			!strings.HasPrefix(decision.Path, "networks.") &&
+			!strings.HasPrefix(decision.Path, "x-uds.") {
+			t.Fatalf("inferred path %q is not part of the Compose or x-uds configuration shape", decision.Path)
+		}
+		if decision.Path == "x-uds.metadata.name" && !strings.Contains(decision.Message, "Kubernetes namespace") {
+			t.Fatalf("inferred package name does not explain namespace derivation: %#v", decision)
+		}
+	}
+	if len(report.Rejected) != 0 {
+		t.Fatalf("rejected decisions = %#v, want none", report.Rejected)
+	}
+	zarfConfig, err := os.ReadFile(filepath.Join(outputPath, "zarf.yaml"))
+	if err != nil {
+		t.Fatalf("read zarf.yaml: %v", err)
+	}
+	if want := "conversion: docs/conversion.md"; !strings.Contains(string(zarfConfig), want) {
+		t.Fatalf("zarf.yaml does not contain %q\n%s", want, zarfConfig)
+	}
+	if unexpected := "conversion-json:"; strings.Contains(string(zarfConfig), unexpected) {
+		t.Fatalf("zarf.yaml unexpectedly contains %q\n%s", unexpected, zarfConfig)
+	}
+
+	markdown, err := os.ReadFile(filepath.Join(outputPath, "docs", "conversion.md"))
+	if err != nil {
+		t.Fatalf("read Markdown conversion report: %v", err)
+	}
+	for _, heading := range []string{
+		"## Translated settings",
+		"## Inferred settings",
+		"## Ignored settings",
+		"## Rejected settings",
+	} {
+		if !strings.Contains(string(markdown), heading) {
+			t.Fatalf("conversion.md does not contain %q\n%s", heading, markdown)
+		}
+	}
+}
+
+func TestRunWritesRejectedSettingsBeforeReturningConversionError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "compose.yaml")
+	outputPath := filepath.Join(dir, "out")
+	input := []byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    network_mode: host
+`)
+	if err := os.WriteFile(inputPath, input, 0o644); err != nil {
+		t.Fatalf("write Compose input: %v", err)
+	}
+
+	err := run(inputPath, outputPath)
+	if err == nil {
+		t.Fatal("run() error = nil, want compatibility error")
+	}
+	report := readConversionReport(t, filepath.Join(outputPath, "conversion.json"))
+	if len(report.Rejected) != 1 {
+		t.Fatalf("rejected decisions = %#v, want one", report.Rejected)
+	}
+	rejected := report.Rejected[0]
+	if rejected.Path != "services.api.network_mode" || rejected.Code != "service-field" {
+		t.Fatalf("rejected decision = %#v", rejected)
+	}
+	if rejected.Message == "" || rejected.Remediation == "" {
+		t.Fatalf("rejected decision must include a message and remediation: %#v", rejected)
+	}
+
+	markdown, readErr := os.ReadFile(filepath.Join(outputPath, "docs", "conversion.md"))
+	if readErr != nil {
+		t.Fatalf("read Markdown conversion report: %v", readErr)
+	}
+	for _, want := range []string{"services.api.network_mode", "ordinary Compose service networking"} {
+		if !strings.Contains(string(markdown), want) {
+			t.Fatalf("conversion.md does not contain %q\n%s", want, markdown)
+		}
+	}
+	if _, statErr := os.Stat(filepath.Join(outputPath, "zarf.yaml")); !os.IsNotExist(statErr) {
+		t.Fatalf("zarf.yaml should not be generated after rejected settings; stat error = %v", statErr)
+	}
+}
+
+func readConversionReport(t *testing.T, path string) model.ConversionReport {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read conversion report: %v", err)
+	}
+	var report model.ConversionReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("decode conversion report: %v", err)
+	}
+	return report
+}
+
+func assertDecisionPath(t *testing.T, decisions []model.ConversionDecision, path string) {
+	t.Helper()
+	for _, decision := range decisions {
+		if decision.Path == path {
+			return
+		}
+	}
+	t.Fatalf("decision path %q not found in %#v", path, decisions)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -126,6 +126,49 @@ services:
 	}
 }
 
+func TestRunWritesStructuredRenderFailureForInvalidMonitorSetting(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "compose.yaml")
+	outputPath := filepath.Join(dir, "out")
+	input := []byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    ports:
+      - "8080:8080"
+x-uds:
+  spec:
+    monitor:
+      - service: missing
+`)
+	if err := os.WriteFile(inputPath, input, 0o644); err != nil {
+		t.Fatalf("write Compose input: %v", err)
+	}
+
+	err := run(inputPath, outputPath)
+	if err == nil {
+		t.Fatal("run() error = nil, want monitor validation error")
+	}
+
+	report := readConversionReport(t, filepath.Join(outputPath, "conversion.json"))
+	assertDecisionPath(t, report.Rejected, "x-uds.spec.monitor")
+	for _, decision := range report.Rejected {
+		if decision.Path != "x-uds.spec.monitor" {
+			continue
+		}
+		if decision.Code != "invalid-setting" || decision.Remediation == "" {
+			t.Fatalf("unexpected rejected decision = %#v", decision)
+		}
+	}
+	for _, decision := range report.Translated {
+		if decision.Path == "x-uds.spec.monitor" {
+			t.Fatalf("translated decisions unexpectedly include invalid monitor path: %#v", report.Translated)
+		}
+	}
+}
+
 func readConversionReport(t *testing.T, path string) model.ConversionReport {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/main_test.go
+++ b/main_test.go
@@ -248,6 +248,37 @@ services:
 	}
 }
 
+func TestRunWritesFallbackPackageGenerationRemediation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "compose.yaml")
+	outputPath := filepath.Join(dir, "out")
+	if err := os.WriteFile(inputPath, []byte(`name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+`), 0o644); err != nil {
+		t.Fatalf("write Compose input: %v", err)
+	}
+	if err := os.MkdirAll(outputPath, 0o755); err != nil {
+		t.Fatalf("create output directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outputPath, "chart"), []byte("not-a-directory"), 0o644); err != nil {
+		t.Fatalf("create chart file: %v", err)
+	}
+
+	if err := run(inputPath, outputPath); err == nil {
+		t.Fatal("run() error = nil, want package generation error")
+	}
+
+	report := readConversionReport(t, filepath.Join(outputPath, "conversion.json"))
+	decision := findDecision(t, report.Rejected, "package")
+	if decision.Code != "package-generation" || decision.Remediation == "" {
+		t.Fatalf("fallback rejected decision = %#v, want package-generation with remediation", decision)
+	}
+}
+
 func readConversionReport(t *testing.T, path string) model.ConversionReport {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/main_test.go
+++ b/main_test.go
@@ -169,6 +169,85 @@ x-uds:
 	}
 }
 
+func TestRunWritesStructuredSourceDecisionsForRenderFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		wantPath string
+		wantCode string
+	}{
+		{
+			name: "duplicate port name",
+			input: `name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    ports:
+      - name: web_api
+        target: 8080
+        published: "8080"
+      - name: web-api
+        target: 9090
+        published: "9090"
+`,
+			wantPath: "services.api.ports",
+			wantCode: "duplicate-port-name",
+		},
+		{
+			name: "invalid environment name preserves raw service path",
+			input: `name: demo
+services:
+  my_api:
+    image: ghcr.io/acme/api:1.2.3
+    environment:
+      DATABASE/URL: postgres://db
+`,
+			wantPath: "services.my_api.environment",
+			wantCode: "environment-name",
+		},
+		{
+			name: "generated variable collision",
+			input: `name: demo
+services:
+  api:
+    image: ghcr.io/acme/api:1.2.3
+    environment:
+      CPU_LIMIT: custom
+`,
+			wantPath: "services.api.environment",
+			wantCode: "zarf-variable-conflict",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			inputPath := filepath.Join(dir, "compose.yaml")
+			outputPath := filepath.Join(dir, "out")
+			if err := os.WriteFile(inputPath, []byte(tt.input), 0o644); err != nil {
+				t.Fatalf("write Compose input: %v", err)
+			}
+
+			if err := run(inputPath, outputPath); err == nil {
+				t.Fatal("run() error = nil, want render validation error")
+			}
+			report := readConversionReport(t, filepath.Join(outputPath, "conversion.json"))
+			decision := findDecision(t, report.Rejected, tt.wantPath)
+			if decision.Code != tt.wantCode || decision.Remediation == "" {
+				t.Fatalf("rejected decision = %#v, want code %q with remediation", decision, tt.wantCode)
+			}
+			for _, translated := range report.Translated {
+				if translated.Path == tt.wantPath {
+					t.Fatalf("translated decisions unexpectedly include rejected path: %#v", report.Translated)
+				}
+			}
+		})
+	}
+}
+
 func readConversionReport(t *testing.T, path string) model.ConversionReport {
 	t.Helper()
 	data, err := os.ReadFile(path)
@@ -190,4 +269,15 @@ func assertDecisionPath(t *testing.T, decisions []model.ConversionDecision, path
 		}
 	}
 	t.Fatalf("decision path %q not found in %#v", path, decisions)
+}
+
+func findDecision(t *testing.T, decisions []model.ConversionDecision, path string) model.ConversionDecision {
+	t.Helper()
+	for _, decision := range decisions {
+		if decision.Path == path {
+			return decision
+		}
+	}
+	t.Fatalf("decision path %q not found in %#v", path, decisions)
+	return model.ConversionDecision{}
 }


### PR DESCRIPTION
## Summary

Adds conversion reports that explain how Docker Compose settings were handled during UDS package generation.

- Writes `conversion.json` for automation.
- Writes `docs/conversion.md` for people.
- Categorizes settings as translated, inferred, ignored, or rejected.
- Includes rejection codes, messages, and remediation guidance.
- Emits reports even when conversion fails.
- Includes only `docs/conversion.md` in the Zarf package documentation; `conversion.json` remains in the conversion output.

## Testing

- `GOCACHE=/tmp/compose-bridge-uds-go-cache go test ./...`
- `GOCACHE=/tmp/compose-bridge-uds-go-cache go vet ./...`
- `git diff --check`

Closes #117 
