### PR TITLE
fix: preserve external Compose ConfigMap names

### DIFF
--- a/docs/compose-support.md
+++ b/docs/compose-support.md
@@ -77,10 +77,12 @@ Secret. Build secrets are unaffected by this runtime-secret behavior.
 Compose configs with inline `content:` become package-owned ConfigMaps. A native
 Compose `external: true` config is not created by the generated chart. Instead,
 the package declares non-sensitive `<CONFIG>_CONFIGMAP_NAME` and
-`<CONFIG>_CONFIGMAP_KEY` Zarf variables. The name has no default and must
-identify an existing ConfigMap in the package namespace. The key defaults to the
-normalized Compose config name. The selected key is mounted at the file path
-declared by the service's config reference. External ConfigMaps are mounted with
+`<CONFIG>_CONFIGMAP_KEY` Zarf variables. The ConfigMap name variable defaults to
+the Compose config's platform name: its declared `name:`, or its logical key
+when `name:` is omitted. The name must identify an existing ConfigMap in the
+package namespace. The key defaults to the normalized Compose config name. The
+selected key is mounted at the file path declared by the service's config
+reference. External ConfigMaps are mounted with
 `subPath`, so updates require a Pod restart. To have UDS trigger that restart,
 the external ConfigMap's owner must apply the `uds.dev/pod-reload: "true"`
 label; otherwise perform a rollout after changing it.

--- a/internal/compose/canonical.go
+++ b/internal/compose/canonical.go
@@ -1268,7 +1268,7 @@ func normalizeTopLevelSecrets(raw types.Secrets) (map[string]model.Secret, map[s
 
 func normalizeTopLevelConfigs(raw types.Configs) (map[string]model.Config, map[string]string, error) {
 	configs := map[string]model.Config{}
-	candidates := make([]namedResourceAlias, 0, len(raw))
+	aliases := map[string]string{}
 	keys := make([]string, 0, len(raw))
 	for key := range raw {
 		keys = append(keys, key)
@@ -1283,12 +1283,14 @@ func normalizeTopLevelConfigs(raw types.Configs) (map[string]model.Config, map[s
 		if _, exists := configs[normalized]; exists {
 			return nil, nil, fmt.Errorf("duplicate normalized top-level config name %q", normalized)
 		}
-		configs[normalized] = model.Config{Name: normalized, External: bool(value.External), Content: value.Content}
-		candidates = append(candidates, namedResourceAlias{Key: key, Normalized: normalized, PlatformName: value.Name})
-	}
-	aliases, err := buildNamedResourceAliases("config", candidates)
-	if err != nil {
-		return nil, nil, err
+		configs[normalized] = model.Config{
+			Name:         normalized,
+			ExternalName: strings.TrimSpace(value.Name),
+			External:     bool(value.External),
+			Content:      value.Content,
+		}
+		registerAlias(aliases, key, normalized)
+		registerAlias(aliases, normalized, normalized)
 	}
 	return configs, aliases, nil
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -84,9 +84,10 @@ type Secret struct {
 }
 
 type Config struct {
-	Name     string
-	External bool
-	Content  string
+	Name         string
+	ExternalName string
+	External     bool
+	Content      string
 }
 
 type Dependency struct {

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -327,7 +327,7 @@ func buildConfigurationDocumentation(app model.App, secretVariables map[string]s
 			continue
 		}
 		variable := configVariables[configName]
-		writeDocumentationVariable(&content, variable.ConfigMapName, fmt.Sprintf("Kubernetes ConfigMap name for external Compose config %s", configName), "", false)
+		writeDocumentationVariable(&content, variable.ConfigMapName, fmt.Sprintf("Kubernetes ConfigMap name for external Compose config %s", configName), config.ExternalName, false)
 		writeDocumentationVariable(&content, variable.ConfigMapKey, fmt.Sprintf("Key in the Kubernetes ConfigMap for external Compose config %s", configName), config.Name, false)
 	}
 
@@ -795,7 +795,10 @@ func writeChartValues(
 			continue
 		}
 		variable := configVariables[name]
-		external := externalResourceValues{Key: plainChartString(config.Name)}
+		external := externalResourceValues{
+			Name: plainChartString(config.ExternalName),
+			Key:  plainChartString(config.Name),
+		}
 		if placeholder {
 			external.Name = zarfChartString(variable.ConfigMapName)
 			external.Key = zarfChartString(variable.ConfigMapKey)
@@ -888,6 +891,7 @@ func writeZarfConfig(
 			zarfVariable{
 				Name:        variable.ConfigMapName,
 				Description: fmt.Sprintf("Kubernetes ConfigMap name for external compose config %s", configName),
+				Default:     optionalStringPointer(config.ExternalName),
 				AutoIndent:  true,
 			},
 			zarfVariable{
@@ -2291,6 +2295,13 @@ func normalizeZarfVariableName(raw string) string {
 
 func stringPointer(value string) *string {
 	return &value
+}
+
+func optionalStringPointer(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return stringPointer(value)
 }
 
 func buildPortName(port model.Port) string {

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -3731,7 +3731,7 @@ configs:
 	for _, want := range []string{
 		"externalConfigs:",
 		"OPERATOR_SETTINGS:",
-		"name: \"\"",
+		"name: operator-settings",
 		"key: operator-settings",
 	} {
 		if !strings.Contains(chartValues, want) {
@@ -3765,7 +3765,7 @@ configs:
 
 	configuration := readFile(t, filepath.Join(outDir, "docs", "configuration.md"))
 	for _, want := range []string{
-		"| `OPERATOR_SETTINGS_CONFIGMAP_NAME` | Kubernetes ConfigMap name for external Compose config operator-settings | — | false |",
+		"| `OPERATOR_SETTINGS_CONFIGMAP_NAME` | Kubernetes ConfigMap name for external Compose config operator-settings | operator-settings | false |",
 		"| `OPERATOR_SETTINGS_CONFIGMAP_KEY` | Key in the Kubernetes ConfigMap for external Compose config operator-settings | operator-settings | false |",
 	} {
 		if !strings.Contains(configuration, want) {
@@ -3785,6 +3785,87 @@ configs:
 		if !strings.Contains(deployment, want) {
 			t.Fatalf("expected custom external config file mount %q\n%s", want, deployment)
 		}
+	}
+}
+
+func TestWritePackageExternalConfigUsesDeclaredPlatformNameAsDefault(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: shop
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    configs:
+      - source: settings
+        target: /etc/shop/settings.yaml
+configs:
+  settings:
+    external: true
+    name: shared-settings
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("LoadCanonicalYAML() error = %v", err)
+	}
+	outDir := t.TempDir()
+	if err := render.WritePackage(outDir, app); err != nil {
+		t.Fatalf("WritePackage() error = %v", err)
+	}
+
+	t.Run("Helm chart default", func(t *testing.T) {
+		chartValues := readYAMLMap(t, filepath.Join(outDir, "chart", "values.yaml"))
+		externalConfigs := mustMap(t, chartValues["externalConfigs"])
+		settings := mustMap(t, externalConfigs["SETTINGS"])
+		if got := settings["name"]; got != "shared-settings" {
+			t.Fatalf("externalConfigs.SETTINGS.name = %#v, want declared Compose platform name %q", got, "shared-settings")
+		}
+	})
+
+	t.Run("Zarf variable default", func(t *testing.T) {
+		zarfConfig := readYAMLMap(t, filepath.Join(outDir, "zarf.yaml"))
+		for _, raw := range zarfConfig["variables"].([]any) {
+			variable := mustMap(t, raw)
+			if variable["name"] != "SETTINGS_CONFIGMAP_NAME" {
+				continue
+			}
+			if got := variable["default"]; got != "shared-settings" {
+				t.Fatalf("SETTINGS_CONFIGMAP_NAME default = %#v, want declared Compose platform name %q", got, "shared-settings")
+			}
+			return
+		}
+		t.Fatal("zarf.yaml does not declare SETTINGS_CONFIGMAP_NAME")
+	})
+}
+
+func TestLoadCanonicalAllowsConfigsSharingExternalPlatformName(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`name: shop
+services:
+  api:
+    image: ghcr.io/acme/api:1.0.0
+    configs:
+      - source: api-settings
+        target: /etc/shop/settings.yaml
+configs:
+  api-settings:
+    external: true
+    name: shared-settings
+  worker-settings:
+    external: true
+    name: shared-settings
+`)
+
+	app, err := compose.LoadCanonicalYAML(input)
+	if err != nil {
+		t.Fatalf("two logical configs may refer to the same external platform object: %v", err)
+	}
+	if _, exists := app.Configs["api-settings"]; !exists {
+		t.Fatalf("referenced logical config was not retained: %#v", app.Configs)
+	}
+	if _, exists := app.Configs["worker-settings"]; exists {
+		t.Fatalf("unreferenced logical config should be pruned: %#v", app.Configs)
 	}
 }
 
@@ -3909,7 +3990,7 @@ configs:
 	}
 }
 
-func TestLoadCanonicalConfigLogicalKeyPrecedesPlatformNameAlias(t *testing.T) {
+func TestLoadCanonicalConfigResolvesLogicalKeyIndependentlyOfPlatformName(t *testing.T) {
 	t.Parallel()
 
 	input := []byte(`name: shop
@@ -3942,7 +4023,7 @@ configs:
 			t.Fatalf("expected logical settings config to be retained on iteration %d: %#v", i, app.Configs)
 		}
 		if _, exists := app.Configs["actual"]; exists {
-			t.Fatalf("platform-name alias incorrectly retained actual config on iteration %d: %#v", i, app.Configs)
+			t.Fatalf("platform name incorrectly replaced logical reference on iteration %d: %#v", i, app.Configs)
 		}
 	}
 }


### PR DESCRIPTION
Compose distinguishes between a logical config key, which services use in configs[].source, and the platform resource name declared with name:. Previously, the bridge treated the platform name as another source alias. This caused valid configurations sharing an external ConfigMap name to be rejected as ambiguous and discarded the declared name when generating deployment defaults.

This change:
- Resolves service config references using logical Compose keys.
- Preserves the external platform name separately.
- Uses the declared platform name as the generated ConfigMap-name default.
- Falls back to the logical key when name: is omitted.
- Allows multiple logical configs to reference the same external ConfigMap.
- Updates generated documentation and regression tests accordingly.
