### PR TITLE
chore(container): add OCI image metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,8 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
         with:
           images: ghcr.io/defenseunicorns/compose-bridge-uds
           tags: |
@@ -61,3 +63,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,10 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM scratch
 
-LABEL com.docker.compose.bridge=transformation
+LABEL com.docker.compose.bridge=transformation \
+      org.opencontainers.image.source="https://github.com/defenseunicorns-labs/compose-bridge-uds" \
+      org.opencontainers.image.description="Transform Docker Compose applications into deployable UDS packages." \
+      org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --from=builder \
      --chown=65532:65532 \


### PR DESCRIPTION
## Summary

  - add OCI source, description, and license labels to the container image
  - propagate image metadata as manifest and index annotations
  - ensure the description appears in GHCR for the multi-architecture image

  ## Testing

  - `go test ./...`
  - built the image locally with Docker Buildx
  - verified the resulting OCI labels with `docker image inspect`

  Closes #118